### PR TITLE
Add linux/arm64 platform to build matrix.

### DIFF
--- a/.github/workflows/build-gpdb6.yml
+++ b/.github/workflows/build-gpdb6.yml
@@ -3,7 +3,7 @@ name: build-gpdb6
 on: [push, pull_request]
 
 env:
-  build_platforms: "linux/amd64"
+  build_platforms: "linux/amd64,linux/arm64"
 
 jobs:
   build_image:

--- a/.github/workflows/build-gpdb7.yml
+++ b/.github/workflows/build-gpdb7.yml
@@ -3,7 +3,7 @@ name: build-gpdb7
 on: [push, pull_request]
 
 env:
-  build_platforms: "linux/amd64"
+  build_platforms: "linux/amd64,linux/arm64"
 
 jobs:
   build_image:

--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,10 @@ build_gpdb_7_oraclelinux:
 
 define build_image
 	@echo "Build GPDB $(1):$(2) $(3) docker image"
-	docker buildx build --platform linux/amd64 -f docker/$(3)/$(1)/Dockerfile --build-arg GPDB_VERSION=$(2) -t greenplum:$(2) .
+	docker buildx build -f docker/$(3)/$(1)/Dockerfile --build-arg GPDB_VERSION=$(2) -t greenplum:$(2) .
 endef
 
 define build_image_with_tag
 	@echo "Build GPDB $(1):$(2) $(3) docker image"
-	docker buildx build --platform linux/amd64 -f docker/$(3)/$(1)/Dockerfile --build-arg GPDB_VERSION=$(2) -t greenplum:$(2)-$(3) .
+	docker buildx build -f docker/$(3)/$(1)/Dockerfile --build-arg GPDB_VERSION=$(2) -t greenplum:$(2)-$(3) .
 endef

--- a/README.md
+++ b/README.md
@@ -43,17 +43,17 @@ Required environment variables:
 Supported Greenplum version tags.
 
 Greenplum 6:
-| GPDB Version | Ubuntu 22.04 | Oracle Linux 8 | 
-|---|---|---|
-| 6.27.1| `6.27.1`, `6.27.1-ubuntu22.04` | `6.27.1-oraclelinux8` |
-| 6.26.4| `6.26.4`, `6.26.4-ubuntu22.04` | `6.26.4-oraclelinux8` |
-| 6.25.4| `6.25.4`, `6.25.4-ubuntu22.04` | `6.25.4-oraclelinux8` |
+| GPDB Version | Ubuntu 22.04 | Oracle Linux 8 | Platform |
+|---|---|---| ---|
+| 6.27.1| `6.27.1`, `6.27.1-ubuntu22.04` | `6.27.1-oraclelinux8` | `linux/amd64`, `linux/arm64` |
+| 6.26.4| `6.26.4`, `6.26.4-ubuntu22.04` | `6.26.4-oraclelinux8` | `linux/amd64`, `linux/arm64` |
+| 6.25.4| `6.25.4`, `6.25.4-ubuntu22.04` | `6.25.4-oraclelinux8` | `linux/amd64`, `linux/arm64` |
 
 Greenplum 7:
-| GPDB Version | Ubuntu 22.04 | Oracle Linux 8 | 
-|---|---|---|
-| 7.1.0| `7.1.0`, `7.1.0-ubuntu22.04` | `7.1.0-oraclelinux8` |
-| 7.0.0| `7.0.0`, `7.0.0-ubuntu22.04` | `7.0.0-oraclelinux8` |
+| GPDB Version | Ubuntu 22.04 | Oracle Linux 8 | Platform |
+|---|---|---| ---|
+| 7.1.0| `7.1.0`, `7.1.0-ubuntu22.04` | `7.1.0-oraclelinux8` |  `linux/amd64`, `linux/arm64` |
+| 7.0.0| `7.0.0`, `7.0.0-ubuntu22.04` | `7.0.0-oraclelinux8` |  `linux/amd64`, `linux/arm64` |
 
 ## Pull
 Change `tag` to the version you need.
@@ -159,15 +159,15 @@ make build_gpdb_7_oraclelinux TAG_GPDB_7=7.1.0
 
 Simple manual build:
 ```bash
-docker buildx build --platform linux/amd64 -f docker/ubuntu22.04/6/Dockerfile -t greenplum:6.27.1 .
+docker buildx build -f docker/ubuntu22.04/6/Dockerfile -t greenplum:6.27.1 .
 ```
 
-Manual build with specific version:
+Manual build with specific component version for `linux/amd64` platform:
 ```bash
 docker buildx build --platform linux/amd64 -f docker/ubuntu22.04/6/Dockerfile --build-arg GPDB_VERSION=6.27.1 -t greenplum:6.27.1 .
 ```
 
-Manual build with specific version for components:
+Manual build with specific component versions for `linux/amd64` and `linux/arm64` platforms:
 ```bash
-docker buildx build --platform linux/amd64 -f docker/ubuntu22.04/6/Dockerfile --build-arg GPDB_VERSION=6.27.1 --build-arg DISKQUOTA_VERSION=2.3.0 --build-arg GPBACKUP_VERSION=1.30.5 -t greenplum:6.27.1 .
+docker buildx build --platform linux/amd64,linux/arm64 -f docker/ubuntu22.04/6/Dockerfile --build-arg GPDB_VERSION=6.27.1 --build-arg DISKQUOTA_VERSION=2.3.0 --build-arg GPBACKUP_VERSION=1.30.5 -t greenplum:6.27.1 .
 ```

--- a/docker/oraclelinux8/6/Dockerfile
+++ b/docker/oraclelinux8/6/Dockerfile
@@ -16,7 +16,7 @@ ARG GPBACKUP_VERSION="1.30.5"
 ARG GPBACKUP_S3_PLUGIN_DOWNLOAD_URL="https://github.com/woblerr/gpbackup-s3-plugin/archive/refs/tags"
 ARG GPBACKUP_S3_PLUGIN_VERSION="1.10.2"
 ARG GPBACKMAN_DOWNLOAD_URL="https://github.com/woblerr/gpbackman/archive/refs/tags"
-ARG GPBACKMAN_VERSION="v0.7.1"
+ARG GPBACKMAN_VERSION="v0.7.2"
 ARG GOSU_VERSION="1.17"
 
 FROM oraclelinux:${OL_VERSION} AS builder

--- a/docker/oraclelinux8/7/Dockerfile
+++ b/docker/oraclelinux8/7/Dockerfile
@@ -14,7 +14,7 @@ ARG GPBACKUP_VERSION="1.30.5"
 ARG GPBACKUP_S3_PLUGIN_DOWNLOAD_URL="https://github.com/woblerr/gpbackup-s3-plugin/archive/refs/tags"
 ARG GPBACKUP_S3_PLUGIN_VERSION="1.10.2"
 ARG GPBACKMAN_DOWNLOAD_URL="https://github.com/woblerr/gpbackman/archive/refs/tags"
-ARG GPBACKMAN_VERSION="v0.7.1"
+ARG GPBACKMAN_VERSION="v0.7.2"
 ARG GOSU_VERSION="1.17"
 
 FROM oraclelinux:${OL_VERSION} AS builder

--- a/docker/ubuntu22.04/6/Dockerfile
+++ b/docker/ubuntu22.04/6/Dockerfile
@@ -16,7 +16,7 @@ ARG GPBACKUP_VERSION="1.30.5"
 ARG GPBACKUP_S3_PLUGIN_DOWNLOAD_URL="https://github.com/woblerr/gpbackup-s3-plugin/archive/refs/tags"
 ARG GPBACKUP_S3_PLUGIN_VERSION="1.10.2"
 ARG GPBACKMAN_DOWNLOAD_URL="https://github.com/woblerr/gpbackman/archive/refs/tags"
-ARG GPBACKMAN_VERSION="v0.7.1"
+ARG GPBACKMAN_VERSION="v0.7.2"
 
 FROM ubuntu:${UBUNTU_VERSION} AS builder
 

--- a/docker/ubuntu22.04/7/Dockerfile
+++ b/docker/ubuntu22.04/7/Dockerfile
@@ -14,7 +14,7 @@ ARG GPBACKUP_VERSION="1.30.5"
 ARG GPBACKUP_S3_PLUGIN_DOWNLOAD_URL="https://github.com/woblerr/gpbackup-s3-plugin/archive/refs/tags"
 ARG GPBACKUP_S3_PLUGIN_VERSION="1.10.2"
 ARG GPBACKMAN_DOWNLOAD_URL="https://github.com/woblerr/gpbackman/archive/refs/tags"
-ARG GPBACKMAN_VERSION="v0.7.1"
+ARG GPBACKMAN_VERSION="v0.7.2"
 
 FROM ubuntu:${UBUNTU_VERSION} AS builder
 


### PR DESCRIPTION
Bumped `gpbackman` to `v0.7.2`.  This allowed to add a build for `linux/arm64` platform.