### PR TITLE
Add custom init scripts.

### DIFF
--- a/.github/workflows/build-gpdb6.yml
+++ b/.github/workflows/build-gpdb6.yml
@@ -51,7 +51,7 @@ jobs:
         BUILD_PLATFORMS: ${{ env.build_platforms }}
 
     - name: Build image and push tag to ghcr.io and Docker Hub
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && matrix.os_version == 'ubuntu22.04'
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
       run: |
         echo ${GITHUB_PKG} | docker login ghcr.io -u ${GITHUB_USER} --password-stdin
         echo ${DOCKERHUB_PKG} | docker login -u ${DOCKERHUB_USER} --password-stdin

--- a/.github/workflows/build-gpdb7.yml
+++ b/.github/workflows/build-gpdb7.yml
@@ -48,7 +48,7 @@ jobs:
         BUILD_PLATFORMS: ${{ env.build_platforms }}
 
     - name: Build image and push tag to ghcr.io and Docker Hub
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && matrix.os_version == 'ubuntu22.04'
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
       run: |
         echo ${GITHUB_PKG} | docker login ghcr.io -u ${GITHUB_USER} --password-stdin
         echo ${DOCKERHUB_PKG} | docker login -u ${DOCKERHUB_USER} --password-stdin

--- a/docker-compose/docker-compose.no_mirrors.yaml
+++ b/docker-compose/docker-compose.no_mirrors.yaml
@@ -23,6 +23,7 @@ services:
       - gpmon_password
     volumes:
       # - gpdb-master-data:/data
+      # - ../docs/custom_init_scripts:/docker-entrypoint-initdb.d
       - ./conf/${CONFIG_FOLDER}/gpinitsystem_config_no_mirrors:/tmp/gpinitsystem_config
       - ./conf/hostfile_gpinitsystem:/tmp/hostfile_gpinitsystem
       - ./conf/ssh/id_rsa:/home/gpadmin/.ssh/id_rsa

--- a/docker-compose/docker-compose.no_mirrors_persistent.yaml
+++ b/docker-compose/docker-compose.no_mirrors_persistent.yaml
@@ -24,6 +24,7 @@ services:
     volumes:
       - gpdb-master-data:/data
       # - ./conf/gpinitsystem_config_no_mirrors:/tmp/gpinitsystem_config
+      # - ../docs/custom_init_script:/docker-entrypoint-initdb.d
       - ./conf/hostfile_gpinitsystem:/tmp/hostfile_gpinitsystem
       - ./conf/ssh/id_rsa:/home/gpadmin/.ssh/id_rsa
       - ./conf/ssh/id_rsa.pub:/home/gpadmin/.ssh/id_rsa.pub

--- a/docker-compose/docker-compose.no_mirrors_persistent.yaml
+++ b/docker-compose/docker-compose.no_mirrors_persistent.yaml
@@ -24,7 +24,7 @@ services:
     volumes:
       - gpdb-master-data:/data
       # - ./conf/gpinitsystem_config_no_mirrors:/tmp/gpinitsystem_config
-      # - ../docs/custom_init_script:/docker-entrypoint-initdb.d
+      # - ../docs/custom_init_scripts:/docker-entrypoint-initdb.d
       - ./conf/hostfile_gpinitsystem:/tmp/hostfile_gpinitsystem
       - ./conf/ssh/id_rsa:/home/gpadmin/.ssh/id_rsa
       - ./conf/ssh/id_rsa.pub:/home/gpadmin/.ssh/id_rsa.pub

--- a/docker/files/entrypoint.sh
+++ b/docker/files/entrypoint.sh
@@ -27,7 +27,8 @@ if [ "${uid}" = "0" ]; then
     # Correct user:group.
     chown -R ${GREENPLUM_USER}:${GREENPLUM_GROUP} \
         /home/${GREENPLUM_USER} \
-        ${GREENPLUM_DATA_DIRECTORY}
+        ${GREENPLUM_DATA_DIRECTORY} \
+        /docker-entrypoint-initdb.d
 fi
 
 # Start SSH server.

--- a/docker/files/start_gpdb.sh
+++ b/docker/files/start_gpdb.sh
@@ -154,7 +154,6 @@ execute_custom_init_scripts() {
     if [ -d "${gp_custom_init_dir}" ] && [ -n "$(ls -A ${gp_custom_init_dir})" ]; then
         echo "INFO - Executing custom initialization scripts"
         for script in "${gp_custom_init_dir}"/*; do
-            ls -la "${script}"
             case "${script}" in
                 *.sh)
                     if [ -x "${script}" ]; then

--- a/docker/oraclelinux8/6/Dockerfile
+++ b/docker/oraclelinux8/6/Dockerfile
@@ -330,9 +330,11 @@ RUN groupadd --gid ${GREENPLUM_GID} ${GREENPLUM_GROUP} \
     && echo "export PXF_BASE=${GREENPLUM_DATA_DIRECTORY}/pxf" >> /home/${GREENPLUM_USER}/.bashrc \
     && mkdir -p ${GREENPLUM_DATA_DIRECTORY} \
                 ${GREENPLUM_DATA_DIRECTORY}/pxf \
+                /docker-entrypoint-initdb.d \
     && chown -R ${GREENPLUM_USER}:${GREENPLUM_GROUP} \
         /home/${GREENPLUM_USER}/ \
         ${GREENPLUM_DATA_DIRECTORY} \
+        /docker-entrypoint-initdb.d \
     && ln -s /usr/bin/python2 /usr/bin/python \
     && unlink /etc/localtime \
     && cp /usr/share/zoneinfo/${TZ} /etc/localtime \

--- a/docker/oraclelinux8/7/Dockerfile
+++ b/docker/oraclelinux8/7/Dockerfile
@@ -321,9 +321,11 @@ RUN groupadd --gid ${GREENPLUM_GID} ${GREENPLUM_GROUP} \
     && echo "export PXF_BASE=${GREENPLUM_DATA_DIRECTORY}/pxf" >> /home/${GREENPLUM_USER}/.bashrc \
     && mkdir -p ${GREENPLUM_DATA_DIRECTORY} \
                 ${GREENPLUM_DATA_DIRECTORY}/pxf \
+                /docker-entrypoint-initdb.d \
     && chown -R ${GREENPLUM_USER}:${GREENPLUM_GROUP} \
         /home/${GREENPLUM_USER}/ \
         ${GREENPLUM_DATA_DIRECTORY} \
+        /docker-entrypoint-initdb.d \
 && unlink /etc/localtime \
 && cp /usr/share/zoneinfo/${TZ} /etc/localtime \
 && echo "${TZ}" > /etc/timezone

--- a/docker/ubuntu22.04/6/Dockerfile
+++ b/docker/ubuntu22.04/6/Dockerfile
@@ -284,7 +284,12 @@ RUN groupadd --gid ${GREENPLUM_GID} ${GREENPLUM_GROUP} \
     && echo "PubkeyAcceptedKeyTypes +ssh-rsa" >> /etc/ssh/sshd_config \
     && echo "${GREENPLUM_USER} ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers \
     && echo "source /usr/local/greenplum-db/greenplum_path.sh" > /home/${GREENPLUM_USER}/.bashrc \
-    && echo "export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64" >> /home/${GREENPLUM_USER}/.bashrc \
+    && arch="$(dpkg --print-architecture)" \
+    && case "${arch}" in \
+        arm64) echo "export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-arm64" >> /home/${GREENPLUM_USER}/.bashrc ;; \
+        amd64) echo "export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64" >> /home/${GREENPLUM_USER}/.bashrc ;; \
+        *) echo >&2 "error: unknown/unsupported architecture '${arch}'"; exit 1 ;; \
+    esac \
     && echo 'export PATH="/usr/local/pxf/bin:${PATH}"' >> /home/${GREENPLUM_USER}/.bashrc \
     && echo "export PXF_BASE=${GREENPLUM_DATA_DIRECTORY}/pxf" >> /home/${GREENPLUM_USER}/.bashrc \
     && mkdir -p ${GREENPLUM_DATA_DIRECTORY} \

--- a/docker/ubuntu22.04/6/Dockerfile
+++ b/docker/ubuntu22.04/6/Dockerfile
@@ -289,9 +289,11 @@ RUN groupadd --gid ${GREENPLUM_GID} ${GREENPLUM_GROUP} \
     && echo "export PXF_BASE=${GREENPLUM_DATA_DIRECTORY}/pxf" >> /home/${GREENPLUM_USER}/.bashrc \
     && mkdir -p ${GREENPLUM_DATA_DIRECTORY} \
                 ${GREENPLUM_DATA_DIRECTORY}/pxf \
+                /docker-entrypoint-initdb.d \
     && chown -R ${GREENPLUM_USER}:${GREENPLUM_GROUP} \
         /home/${GREENPLUM_USER}/ \
         ${GREENPLUM_DATA_DIRECTORY} \
+        /docker-entrypoint-initdb.d \
     && ln -s /usr/bin/python2.7 /usr/bin/python \
     && unlink /etc/localtime \
     && cp /usr/share/zoneinfo/${TZ} /etc/localtime \

--- a/docker/ubuntu22.04/7/Dockerfile
+++ b/docker/ubuntu22.04/7/Dockerfile
@@ -274,7 +274,13 @@ RUN groupadd --gid ${GREENPLUM_GID} ${GREENPLUM_GROUP} \
     && echo "PubkeyAcceptedKeyTypes +ssh-rsa" >> /etc/ssh/sshd_config \
     && echo "${GREENPLUM_USER} ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers \
     && echo "source /usr/local/greenplum-db/greenplum_path.sh" > /home/${GREENPLUM_USER}/.bashrc \
-    && echo "export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64" >> /home/${GREENPLUM_USER}/.bashrc \
+    && ARCH=$(dpkg --print-architecture) \
+    && arch="$(dpkg --print-architecture)" \
+    && case "${arch}" in \
+        arm64) echo "export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-arm64" >> /home/${GREENPLUM_USER}/.bashrc ;; \
+        amd64) echo "export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64" >> /home/${GREENPLUM_USER}/.bashrc ;; \
+        *) echo >&2 "error: unknown/unsupported architecture '${arch}'"; exit 1 ;; \
+    esac \
     && echo 'export PATH="/usr/local/pxf/bin:${PATH}"' >> /home/${GREENPLUM_USER}/.bashrc \
     && echo "export PXF_BASE=${GREENPLUM_DATA_DIRECTORY}/pxf" >> /home/${GREENPLUM_USER}/.bashrc \
     && mkdir -p ${GREENPLUM_DATA_DIRECTORY} \

--- a/docker/ubuntu22.04/7/Dockerfile
+++ b/docker/ubuntu22.04/7/Dockerfile
@@ -279,9 +279,11 @@ RUN groupadd --gid ${GREENPLUM_GID} ${GREENPLUM_GROUP} \
     && echo "export PXF_BASE=${GREENPLUM_DATA_DIRECTORY}/pxf" >> /home/${GREENPLUM_USER}/.bashrc \
     && mkdir -p ${GREENPLUM_DATA_DIRECTORY} \
                 ${GREENPLUM_DATA_DIRECTORY}/pxf \
+                /docker-entrypoint-initdb.d \
     && chown -R ${GREENPLUM_USER}:${GREENPLUM_GROUP} \
         /home/${GREENPLUM_USER}/ \
         ${GREENPLUM_DATA_DIRECTORY} \
+        /docker-entrypoint-initdb.d \
     && unlink /etc/localtime \
     && cp /usr/share/zoneinfo/${TZ} /etc/localtime \
     && echo "${TZ}" > /etc/timezone

--- a/docs/custom_init_scripts/00_init.sql
+++ b/docs/custom_init_scripts/00_init.sql
@@ -1,0 +1,7 @@
+CREATE TABLE test_initialization (
+  id serial PRIMARY KEY,
+  name text,
+  created_at timestamp DEFAULT current_timestamp
+);
+
+INSERT INTO test_initialization (name) VALUES ('Initialized via sql script');

--- a/docs/custom_init_scripts/01_init.sh
+++ b/docs/custom_init_scripts/01_init.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+echo "Executing initialization shell script"
+psql -U ${GREENPLUM_USER} -h $(hostname) -d ${GREENPLUM_DATABASE_NAME} -c "INSERT INTO test_initialization (name) VALUES ('Added via shell script');"
+echo "Shell script executed successfully!"


### PR DESCRIPTION
New:
* Added custom initialization scripts. Implemented the ability to run custom `.sql` and `.sh` scripts placed in `/docker-entrypoint-initdb.d` after the Greenplum cluster is initialized and started.
* The logic for initializing segment hosts was moved into a separate function `initialize_and_start_gpdb_segments` within `start_gpdb.sh` for better code organization.

Fix:
* Fixed diskquota initialization. Incorrect variable was used.
* Fixed push to registry in CI for Oracle Linux images.
* Fixed `JAVA_HOME` for different platforms in Ubuntu images.
