### PR TITLE
Use native ARM64 runners for multi-platform builds.

### DIFF
--- a/.github/workflows/build-gpdb6.yml
+++ b/.github/workflows/build-gpdb6.yml
@@ -51,7 +51,7 @@ jobs:
           --platform ${{ matrix.platform }} \
           --build-arg GPDB_VERSION=${TAG} \
           --build-arg REPO_BUILD_TAG=${REPO_TAG} \
-          -t greenplum:${TAG} .
+          -t greenplum:${TAG}-${ARCH} .
       env: 
         TAG: ${{ matrix.greenplum_version }}
         OS_TAG: ${{ matrix.os_version }}

--- a/.github/workflows/build-gpdb6.yml
+++ b/.github/workflows/build-gpdb6.yml
@@ -2,19 +2,14 @@ name: build-gpdb6
 
 on: [push, pull_request]
 
-env:
-  build_platforms: "linux/amd64,linux/arm64"
-
 jobs:
   build_image:
-    # Pin ubuntu-22.04.
-    # See https://github.com/actions/runner-images/issues/11471
-    # runs-on: ubuntu-latest
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.platform == 'linux/arm64' && 'ubuntu-22.04-arm' || 'ubuntu-22.04' }}
     strategy:
       matrix:
         greenplum_version: ["6.27.1"]
         os_version: ["ubuntu22.04", "oraclelinux8"]
+        platform: ["linux/amd64", "linux/arm64"]
     steps:
     - uses: actions/checkout@v4
 
@@ -22,25 +17,38 @@ jobs:
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
       id: vars
       run: |
-        echo ::set-output name=repo_tag::$(echo ${GITHUB_REF} | cut -d'/' -f3)
+        echo "repo_tag=$(echo ${GITHUB_REF} | cut -d'/' -f3)" >> $GITHUB_OUTPUT
     
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+    - name: Set Architecture
+      run: |
+        if [ "${{ matrix.platform }}" = "linux/amd64" ]; then
+          echo "ARCH=amd64" >> $GITHUB_ENV
+        else
+          echo "ARCH=arm64" >> $GITHUB_ENV
+        fi
 
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@v3
 
-    - name: Available platforms
-      run: echo ${BUILDX_PLATFORMS}
-      env:
-        BUILDX_PLATFORMS: ${{ steps.buildx.outputs.platforms }}
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKEHUB_USER }}
+        password: ${{ secrets.DOCKEHUB_TOKEN }}
 
-    - name: Build greenplum image
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GUTHUB_CR_PAT }}
+
+    - name: Build greenplum image (Test Build)
       run: |
         docker buildx build \
           -f docker/${OS_TAG}/6/Dockerfile \
-          --platform ${BUILD_PLATFORMS} \
+          --platform ${{ matrix.platform }} \
           --build-arg GPDB_VERSION=${TAG} \
           --build-arg REPO_BUILD_TAG=${REPO_TAG} \
           -t greenplum:${TAG} .
@@ -48,22 +56,22 @@ jobs:
         TAG: ${{ matrix.greenplum_version }}
         OS_TAG: ${{ matrix.os_version }}
         REPO_TAG: ${{ steps.vars.outputs.repo_tag }}
-        BUILD_PLATFORMS: ${{ env.build_platforms }}
 
-    - name: Build image and push tag to ghcr.io and Docker Hub
+    - name: Build and push platform specific images
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
       run: |
-        echo ${GITHUB_PKG} | docker login ghcr.io -u ${GITHUB_USER} --password-stdin
-        echo ${DOCKERHUB_PKG} | docker login -u ${DOCKERHUB_USER} --password-stdin
+        GHCR_BASE="ghcr.io/${GITHUB_USER}/greenplum"
+        DH_BASE="${DOCKERHUB_USER}/greenplum"
+
         docker buildx build --push \
             -f docker/${OS_TAG}/6/Dockerfile \
-            --platform ${BUILD_PLATFORMS} \
+            --platform ${{ matrix.platform }} \
             --build-arg GPDB_VERSION=${TAG} \
             --build-arg REPO_BUILD_TAG=${REPO_TAG} \
-            -t ghcr.io/${GITHUB_USER}/greenplum:${TAG}-${OS_TAG} \
-            -t ghcr.io/${GITHUB_USER}/greenplum:${TAG}-${OS_TAG}-${REPO_TAG} \
-            -t ${DOCKERHUB_USER}/greenplum:${TAG}-${OS_TAG} \
-            -t ${DOCKERHUB_USER}/greenplum:${TAG}-${OS_TAG}-${REPO_TAG} .
+            -t ${GHCR_BASE}:${TAG}-${OS_TAG}-${ARCH} \
+            -t ${GHCR_BASE}:${TAG}-${OS_TAG}-${REPO_TAG}-${ARCH} \
+            -t ${DH_BASE}:${TAG}-${OS_TAG}-${ARCH} \
+            -t ${DH_BASE}:${TAG}-${OS_TAG}-${REPO_TAG}-${ARCH} .
       env:
         GITHUB_USER: ${{ github.actor }}
         GITHUB_PKG: ${{ secrets.GUTHUB_CR_PAT }}
@@ -72,28 +80,91 @@ jobs:
         TAG: ${{ matrix.greenplum_version }}
         OS_TAG: ${{ matrix.os_version }}
         REPO_TAG: ${{ steps.vars.outputs.repo_tag }}
-        BUILD_PLATFORMS: ${{ env.build_platforms }}
 
-    - name: Push default tags (ubuntu22.04 only)
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && matrix.os_version == 'ubuntu22.04'
-      run: |
-        echo ${GITHUB_PKG} | docker login ghcr.io -u ${GITHUB_USER} --password-stdin
-        echo ${DOCKERHUB_PKG} | docker login -u ${DOCKERHUB_USER} --password-stdin
-        docker buildx build --push \
-             -f docker/${OS_TAG}/6/Dockerfile \
-            --platform ${BUILD_PLATFORMS} \
-            --build-arg GPDB_VERSION=${TAG} \
-            --build-arg REPO_BUILD_TAG=${REPO_TAG} \
-            -t ghcr.io/${GITHUB_USER}/greenplum:${TAG} \
-            -t ghcr.io/${GITHUB_USER}/greenplum:${TAG}-${REPO_TAG} \
-            -t ${DOCKERHUB_USER}/greenplum:${TAG} \
-            -t ${DOCKERHUB_USER}/greenplum:${TAG}-${REPO_TAG} .
-      env:
-        GITHUB_USER: ${{ github.actor }}
-        GITHUB_PKG: ${{ secrets.GUTHUB_CR_PAT }}
-        DOCKERHUB_USER: ${{ secrets.DOCKEHUB_USER }}
-        DOCKERHUB_PKG: ${{ secrets.DOCKEHUB_TOKEN }}
-        TAG: ${{ matrix.greenplum_version }}
-        OS_TAG: ${{ matrix.os_version }}
-        REPO_TAG: ${{ steps.vars.outputs.repo_tag }}
-        BUILD_PLATFORMS: ${{ env.build_platforms }}
+  merge_manifests:
+    runs-on: ubuntu-22.04
+    needs: build_image
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    strategy:
+      matrix:
+        greenplum_version: ["6.27.1"]
+        os_version: ["ubuntu22.04", "oraclelinux8"]
+    steps:
+      - name: Get repo tag
+        id: vars
+        run: |
+          echo "repo_tag=$(echo ${GITHUB_REF} | cut -d'/' -f3)" >> $GITHUB_OUTPUT
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKEHUB_USER }}
+          password: ${{ secrets.DOCKEHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GUTHUB_CR_PAT }}
+
+      - name: Create and push manifest lists
+        run: |
+          GHCR_BASE="ghcr.io/${GITHUB_USER}/greenplum"
+          DH_BASE="${DOCKERHUB_USER}/greenplum"
+          
+          docker buildx imagetools create -t ${GHCR_BASE}:${TAG}-${OS_TAG} \
+            ${GHCR_BASE}:${TAG}-${OS_TAG}-amd64 \
+            ${GHCR_BASE}:${TAG}-${OS_TAG}-arm64
+            
+          docker buildx imagetools create -t ${DH_BASE}:${TAG}-${OS_TAG} \
+            ${DH_BASE}:${TAG}-${OS_TAG}-amd64 \
+            ${DH_BASE}:${TAG}-${OS_TAG}-arm64
+
+          docker buildx imagetools create -t ${GHCR_BASE}:${TAG}-${OS_TAG}-${REPO_TAG} \
+            ${GHCR_BASE}:${TAG}-${OS_TAG}-${REPO_TAG}-amd64 \
+            ${GHCR_BASE}:${TAG}-${OS_TAG}-${REPO_TAG}-arm64
+            
+          docker buildx imagetools create -t ${DH_BASE}:${TAG}-${OS_TAG}-${REPO_TAG} \
+            ${DH_BASE}:${TAG}-${OS_TAG}-${REPO_TAG}-amd64 \
+            ${DH_BASE}:${TAG}-${OS_TAG}-${REPO_TAG}-arm64
+
+        env:
+          GITHUB_USER: ${{ github.actor }}
+          DOCKERHUB_USER: ${{ secrets.DOCKEHUB_USER }}
+          TAG: ${{ matrix.greenplum_version }}
+          OS_TAG: ${{ matrix.os_version }}
+          REPO_TAG: ${{ steps.vars.outputs.repo_tag }}
+
+      - name: Create and push default manifest lists (ubuntu22.04 only)
+        if: matrix.os_version == 'ubuntu22.04'
+        run: |
+          GHCR_BASE="ghcr.io/${GITHUB_USER}/greenplum"
+          DH_BASE="${DOCKERHUB_USER}/greenplum"
+
+          # 1. Manifest for ${TAG}
+          docker buildx imagetools create -t ${GHCR_BASE}:${TAG} \
+            ${GHCR_BASE}:${TAG}-${OS_TAG}-amd64 \
+            ${GHCR_BASE}:${TAG}-${OS_TAG}-arm64
+            
+          docker buildx imagetools create -t ${DH_BASE}:${TAG} \
+            ${DH_BASE}:${TAG}-${OS_TAG}-amd64 \
+            ${DH_BASE}:${TAG}-${OS_TAG}-arm64
+
+          # 2. Manifest for ${TAG}-${REPO_TAG}
+          docker buildx imagetools create -t ${GHCR_BASE}:${TAG}-${REPO_TAG} \
+            ${GHCR_BASE}:${TAG}-${OS_TAG}-${REPO_TAG}-amd64 \
+            ${GHCR_BASE}:${TAG}-${OS_TAG}-${REPO_TAG}-arm64
+            
+          docker buildx imagetools create -t ${DH_BASE}:${TAG}-${REPO_TAG} \
+            ${DH_BASE}:${TAG}-${OS_TAG}-${REPO_TAG}-amd64 \
+            ${DH_BASE}:${TAG}-${OS_TAG}-${REPO_TAG}-arm64
+        env:
+          GITHUB_USER: ${{ github.actor }}
+          DOCKERHUB_USER: ${{ secrets.DOCKEHUB_USER }}
+          TAG: ${{ matrix.greenplum_version }}
+          OS_TAG: ${{ matrix.os_version }}
+          REPO_TAG: ${{ steps.vars.outputs.repo_tag }}

--- a/.github/workflows/build-gpdb7.yml
+++ b/.github/workflows/build-gpdb7.yml
@@ -2,16 +2,15 @@ name: build-gpdb7
 
 on: [push, pull_request]
 
-env:
-  build_platforms: "linux/amd64,linux/arm64"
-
 jobs:
   build_image:
-    runs-on: ubuntu-22.04
+    # Use native ARM64 runners for arm64 platform, standard x64 runners for amd64
+    runs-on: ${{ matrix.platform == 'linux/arm64' && 'ubuntu-22.04-arm' || 'ubuntu-22.04' }}
     strategy:
       matrix:
         greenplum_version: ["7.1.0"]
         os_version: ["ubuntu22.04", "oraclelinux8"]
+        platform: ["linux/amd64", "linux/arm64"]
     steps:
     - uses: actions/checkout@v4
 
@@ -19,25 +18,38 @@ jobs:
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
       id: vars
       run: |
-        echo ::set-output name=repo_tag::$(echo ${GITHUB_REF} | cut -d'/' -f3)
+        echo "repo_tag=$(echo ${GITHUB_REF} | cut -d'/' -f3)" >> $GITHUB_OUTPUT
     
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+    - name: Set Architecture
+      run: |
+        if [ "${{ matrix.platform }}" = "linux/amd64" ]; then
+          echo "ARCH=amd64" >> $GITHUB_ENV
+        else
+          echo "ARCH=arm64" >> $GITHUB_ENV
+        fi
 
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@v3
 
-    - name: Available platforms
-      run: echo ${BUILDX_PLATFORMS}
-      env:
-        BUILDX_PLATFORMS: ${{ steps.buildx.outputs.platforms }}
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKEHUB_USER }}
+        password: ${{ secrets.DOCKEHUB_TOKEN }}
 
-    - name: Build greenplum image
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GUTHUB_CR_PAT }}
+
+    - name: Build greenplum image (Test Build)
       run: |
         docker buildx build \
           -f docker/${OS_TAG}/7/Dockerfile \
-          --platform ${BUILD_PLATFORMS} \
+          --platform ${{ matrix.platform }} \
           --build-arg GPDB_VERSION=${TAG} \
           --build-arg REPO_BUILD_TAG=${REPO_TAG} \
           -t greenplum:${TAG} .
@@ -45,22 +57,22 @@ jobs:
         TAG: ${{ matrix.greenplum_version }}
         OS_TAG: ${{ matrix.os_version }}
         REPO_TAG: ${{ steps.vars.outputs.repo_tag }}
-        BUILD_PLATFORMS: ${{ env.build_platforms }}
 
-    - name: Build image and push tag to ghcr.io and Docker Hub
+    - name: Build and push platform specific images
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
       run: |
-        echo ${GITHUB_PKG} | docker login ghcr.io -u ${GITHUB_USER} --password-stdin
-        echo ${DOCKERHUB_PKG} | docker login -u ${DOCKERHUB_USER} --password-stdin
+        GHCR_BASE="ghcr.io/${GITHUB_USER}/greenplum"
+        DH_BASE="${DOCKERHUB_USER}/greenplum"
+
         docker buildx build --push \
             -f docker/${OS_TAG}/7/Dockerfile \
-            --platform ${BUILD_PLATFORMS} \
+            --platform ${{ matrix.platform }} \
             --build-arg GPDB_VERSION=${TAG} \
             --build-arg REPO_BUILD_TAG=${REPO_TAG} \
-            -t ghcr.io/${GITHUB_USER}/greenplum:${TAG}-${OS_TAG} \
-            -t ghcr.io/${GITHUB_USER}/greenplum:${TAG}-${OS_TAG}-${REPO_TAG} \
-            -t ${DOCKERHUB_USER}/greenplum:${TAG}-${OS_TAG} \
-            -t ${DOCKERHUB_USER}/greenplum:${TAG}-${OS_TAG}-${REPO_TAG} .
+            -t ${GHCR_BASE}:${TAG}-${OS_TAG}-${ARCH} \
+            -t ${GHCR_BASE}:${TAG}-${OS_TAG}-${REPO_TAG}-${ARCH} \
+            -t ${DH_BASE}:${TAG}-${OS_TAG}-${ARCH} \
+            -t ${DH_BASE}:${TAG}-${OS_TAG}-${REPO_TAG}-${ARCH} .
       env:
         GITHUB_USER: ${{ github.actor }}
         GITHUB_PKG: ${{ secrets.GUTHUB_CR_PAT }}
@@ -69,28 +81,91 @@ jobs:
         TAG: ${{ matrix.greenplum_version }}
         OS_TAG: ${{ matrix.os_version }}
         REPO_TAG: ${{ steps.vars.outputs.repo_tag }}
-        BUILD_PLATFORMS: ${{ env.build_platforms }}
 
-    - name: Push default tags (ubuntu22.04 only)
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && matrix.os_version == 'ubuntu22.04'
-      run: |
-        echo ${GITHUB_PKG} | docker login ghcr.io -u ${GITHUB_USER} --password-stdin
-        echo ${DOCKERHUB_PKG} | docker login -u ${DOCKERHUB_USER} --password-stdin
-        docker buildx build --push \
-             -f docker/${OS_TAG}/7/Dockerfile \
-            --platform ${BUILD_PLATFORMS} \
-            --build-arg GPDB_VERSION=${TAG} \
-            --build-arg REPO_BUILD_TAG=${REPO_TAG} \
-            -t ghcr.io/${GITHUB_USER}/greenplum:${TAG} \
-            -t ghcr.io/${GITHUB_USER}/greenplum:${TAG}-${REPO_TAG} \
-            -t ${DOCKERHUB_USER}/greenplum:${TAG} \
-            -t ${DOCKERHUB_USER}/greenplum:${TAG}-${REPO_TAG} .
-      env:
-        GITHUB_USER: ${{ github.actor }}
-        GITHUB_PKG: ${{ secrets.GUTHUB_CR_PAT }}
-        DOCKERHUB_USER: ${{ secrets.DOCKEHUB_USER }}
-        DOCKERHUB_PKG: ${{ secrets.DOCKEHUB_TOKEN }}
-        TAG: ${{ matrix.greenplum_version }}
-        OS_TAG: ${{ matrix.os_version }}
-        REPO_TAG: ${{ steps.vars.outputs.repo_tag }}
-        BUILD_PLATFORMS: ${{ env.build_platforms }}
+  merge_manifests:
+    runs-on: ubuntu-22.04
+    needs: build_image
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    strategy:
+      matrix:
+        greenplum_version: ["7.1.0"]
+        os_version: ["ubuntu22.04", "oraclelinux8"]
+    steps:
+      - name: Get repo tag
+        id: vars
+        run: |
+          echo "repo_tag=$(echo ${GITHUB_REF} | cut -d'/' -f3)" >> $GITHUB_OUTPUT
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKEHUB_USER }}
+          password: ${{ secrets.DOCKEHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GUTHUB_CR_PAT }}
+
+      - name: Create and push manifest lists
+        run: |
+          GHCR_BASE="ghcr.io/${GITHUB_USER}/greenplum"
+          DH_BASE="${DOCKERHUB_USER}/greenplum"
+          
+          docker buildx imagetools create -t ${GHCR_BASE}:${TAG}-${OS_TAG} \
+            ${GHCR_BASE}:${TAG}-${OS_TAG}-amd64 \
+            ${GHCR_BASE}:${TAG}-${OS_TAG}-arm64
+            
+          docker buildx imagetools create -t ${DH_BASE}:${TAG}-${OS_TAG} \
+            ${DH_BASE}:${TAG}-${OS_TAG}-amd64 \
+            ${DH_BASE}:${TAG}-${OS_TAG}-arm64
+
+          docker buildx imagetools create -t ${GHCR_BASE}:${TAG}-${OS_TAG}-${REPO_TAG} \
+            ${GHCR_BASE}:${TAG}-${OS_TAG}-${REPO_TAG}-amd64 \
+            ${GHCR_BASE}:${TAG}-${OS_TAG}-${REPO_TAG}-arm64
+            
+          docker buildx imagetools create -t ${DH_BASE}:${TAG}-${OS_TAG}-${REPO_TAG} \
+            ${DH_BASE}:${TAG}-${OS_TAG}-${REPO_TAG}-amd64 \
+            ${DH_BASE}:${TAG}-${OS_TAG}-${REPO_TAG}-arm64
+
+        env:
+          GITHUB_USER: ${{ github.actor }}
+          DOCKERHUB_USER: ${{ secrets.DOCKEHUB_USER }}
+          TAG: ${{ matrix.greenplum_version }}
+          OS_TAG: ${{ matrix.os_version }}
+          REPO_TAG: ${{ steps.vars.outputs.repo_tag }}
+
+      - name: Create and push default manifest lists (ubuntu22.04 only)
+        if: matrix.os_version == 'ubuntu22.04'
+        run: |
+          GHCR_BASE="ghcr.io/${GITHUB_USER}/greenplum"
+          DH_BASE="${DOCKERHUB_USER}/greenplum"
+
+          # 1. Manifest for ${TAG}
+          docker buildx imagetools create -t ${GHCR_BASE}:${TAG} \
+            ${GHCR_BASE}:${TAG}-${OS_TAG}-amd64 \
+            ${GHCR_BASE}:${TAG}-${OS_TAG}-arm64
+            
+          docker buildx imagetools create -t ${DH_BASE}:${TAG} \
+            ${DH_BASE}:${TAG}-${OS_TAG}-amd64 \
+            ${DH_BASE}:${TAG}-${OS_TAG}-arm64
+
+          # 2. Manifest for ${TAG}-${REPO_TAG}
+          docker buildx imagetools create -t ${GHCR_BASE}:${TAG}-${REPO_TAG} \
+            ${GHCR_BASE}:${TAG}-${OS_TAG}-${REPO_TAG}-amd64 \
+            ${GHCR_BASE}:${TAG}-${OS_TAG}-${REPO_TAG}-arm64
+            
+          docker buildx imagetools create -t ${DH_BASE}:${TAG}-${REPO_TAG} \
+            ${DH_BASE}:${TAG}-${OS_TAG}-${REPO_TAG}-amd64 \
+            ${DH_BASE}:${TAG}-${OS_TAG}-${REPO_TAG}-arm64
+        env:
+          GITHUB_USER: ${{ github.actor }}
+          DOCKERHUB_USER: ${{ secrets.DOCKEHUB_USER }}
+          TAG: ${{ matrix.greenplum_version }}
+          OS_TAG: ${{ matrix.os_version }}
+          REPO_TAG: ${{ steps.vars.outputs.repo_tag }}

--- a/.github/workflows/build-gpdb7.yml
+++ b/.github/workflows/build-gpdb7.yml
@@ -52,7 +52,7 @@ jobs:
           --platform ${{ matrix.platform }} \
           --build-arg GPDB_VERSION=${TAG} \
           --build-arg REPO_BUILD_TAG=${REPO_TAG} \
-          -t greenplum:${TAG} .
+          -t greenplum:${TAG}-${ARCH} .
       env: 
         TAG: ${{ matrix.greenplum_version }}
         OS_TAG: ${{ matrix.os_version }}


### PR DESCRIPTION
Replace QEMU emulation with native GitHub ARM64 runners (ubuntu-22.04-arm) for ARM64 platform builds.

Changes:
- Use ubuntu-22.04-arm runner for linux/arm64 builds
- Keep ubuntu-22.04 runner for linux/amd64 builds
- Set ARCH environment variable dynamically based on platform