### PR TITLE
Small refactoring for greengage and wal-g.

### DIFF
--- a/docker-compose/.env
+++ b/docker-compose/.env
@@ -24,7 +24,7 @@ CONFIG_FOLDER="6"
 # Greengage
 # For Greengage 6 on Ubuntu 22.04
 #IMAGE_NAME="greengage"
-#TAG=6.29.2
+#TAG=6.29.2-ubuntu22.04
 #CONFIG_FOLDER="6"
 
 # For Greengage 6 on Oracle Linux 8
@@ -34,7 +34,7 @@ CONFIG_FOLDER="6"
 
 # For Greengage 7 on Ubuntu 22.04
 #IMAGE_NAME="greengage"
-#TAG=7.4.1
+#TAG=7.4.1-ubuntu22.04
 #CONFIG_FOLDER="7"
 
 # For Greengage 7 on Oracle Linux 8

--- a/docker/greengage/oraclelinux8/6/Dockerfile
+++ b/docker/greengage/oraclelinux8/6/Dockerfile
@@ -40,6 +40,7 @@ ARG GPBACKMAN_DOWNLOAD_URL="https://github.com/woblerr/gpbackman/archive/refs/ta
 ARG GPBACKMAN_VERSION="v0.8.1"
 # Greengage use pgBackRest fork for physical backups.
 # It is not clear whether wal-g will work correctly.
+# Will be error like: "unknown flavor: PostgreSQL 9.4.26 (Greengage Database 6.29.2 build dev)"
 #ARG WALG_DOWNLOAD_URL="https://github.com/wal-g/wal-g"
 ## Wait new WAL-G release
 #ARG WALG_VERSION="4b33c88939ce0cc23acc5f89dcf5e427c50923d9"

--- a/docker/greengage/oraclelinux8/6/Dockerfile
+++ b/docker/greengage/oraclelinux8/6/Dockerfile
@@ -258,8 +258,7 @@ RUN wget ${GPBACKMAN_DOWNLOAD_URL}/${GPBACKMAN_VERSION}.tar.gz -O /tmp/gpbackman
 #       make deps \
 #    && USE_BROTLI=1 \
 #       USE_LIBSODIUM=1 \
-#       make gp_build \
-#    && rm -rf /tmp/wal-g-${WALG_VERSION}.tar.gz
+#       make gp_build
 
 # pxf
 # Build pxf without tests

--- a/docker/greengage/oraclelinux8/7/Dockerfile
+++ b/docker/greengage/oraclelinux8/7/Dockerfile
@@ -240,8 +240,7 @@ RUN wget ${GPBACKMAN_DOWNLOAD_URL}/${GPBACKMAN_VERSION}.tar.gz -O /tmp/gpbackman
 #       make deps \
 #    && USE_BROTLI=1 \
 #       USE_LIBSODIUM=1 \
-#       make gp_build \
-#    && rm -rf /tmp/wal-g-${WALG_VERSION}.tar.gz
+#       make gp_build
 
 # pxf
 # Build pxf without tests

--- a/docker/greengage/oraclelinux8/7/Dockerfile
+++ b/docker/greengage/oraclelinux8/7/Dockerfile
@@ -38,6 +38,7 @@ ARG GPBACKMAN_DOWNLOAD_URL="https://github.com/woblerr/gpbackman/archive/refs/ta
 ARG GPBACKMAN_VERSION="v0.8.1"
 # Greengage use pgBackRest fork for physical backups.
 # It is not clear whether wal-g will work correctly.
+# Will be error like: "unknown flavor: PostgreSQL ... (Greengage Database ... build dev)"
 #ARG WALG_DOWNLOAD_URL="https://github.com/wal-g/wal-g"
 ## Wait new WAL-G release
 #ARG WALG_VERSION="4b33c88939ce0cc23acc5f89dcf5e427c50923d9"

--- a/docker/greengage/ubuntu22.04/6/Dockerfile
+++ b/docker/greengage/ubuntu22.04/6/Dockerfile
@@ -34,6 +34,7 @@ ARG GPBACKMAN_DOWNLOAD_URL="https://github.com/woblerr/gpbackman/archive/refs/ta
 ARG GPBACKMAN_VERSION="v0.8.1"
 # Greengage use pgBackRest fork for physical backups.
 # It is not clear whether wal-g will work correctly.
+# Will be error like: "unknown flavor: PostgreSQL 9.4.26 (Greengage Database 6.29.2 build dev)"
 #ARG WALG_DOWNLOAD_URL="https://github.com/wal-g/wal-g"
 ## Wait new WAL-G release
 #ARG WALG_VERSION="4b33c88939ce0cc23acc5f89dcf5e427c50923d9"

--- a/docker/greengage/ubuntu22.04/6/Dockerfile
+++ b/docker/greengage/ubuntu22.04/6/Dockerfile
@@ -220,8 +220,7 @@ RUN wget ${GPBACKMAN_DOWNLOAD_URL}/${GPBACKMAN_VERSION}.tar.gz -O /tmp/gpbackman
 #       make deps \
 #    && USE_BROTLI=1 \
 #       USE_LIBSODIUM=1 \
-#       make gp_build \
-#    && rm -rf /tmp/wal-g-${WALG_VERSION}.tar.gz
+#       make gp_build
 
 # pxf
 # Build pxf without tests

--- a/docker/greengage/ubuntu22.04/7/Dockerfile
+++ b/docker/greengage/ubuntu22.04/7/Dockerfile
@@ -199,8 +199,7 @@ RUN wget ${GPBACKMAN_DOWNLOAD_URL}/${GPBACKMAN_VERSION}.tar.gz -O /tmp/gpbackman
 #       make deps \
 #    && USE_BROTLI=1 \
 #       USE_LIBSODIUM=1 \
-#       make gp_build \
-#    && rm -rf /tmp/wal-g-${WALG_VERSION}.tar.gz
+#       make gp_build
 
 # pxf
 # Build pxf without tests

--- a/docker/greengage/ubuntu22.04/7/Dockerfile
+++ b/docker/greengage/ubuntu22.04/7/Dockerfile
@@ -30,6 +30,7 @@ ARG GPBACKMAN_DOWNLOAD_URL="https://github.com/woblerr/gpbackman/archive/refs/ta
 ARG GPBACKMAN_VERSION="v0.8.1"
 # Greengage use pgBackRest fork for physical backups.
 # It is not clear whether wal-g will work correctly.
+# Will be error like: "unknown flavor: PostgreSQL ... (Greengage Database ... build dev)"
 #ARG WALG_DOWNLOAD_URL="https://github.com/wal-g/wal-g"
 ## Wait new WAL-G release
 #ARG WALG_VERSION="4b33c88939ce0cc23acc5f89dcf5e427c50923d9"

--- a/docker/greenplum/oraclelinux8/6/Dockerfile
+++ b/docker/greenplum/oraclelinux8/6/Dockerfile
@@ -226,8 +226,7 @@ RUN git clone ${WALG_DOWNLOAD_URL} /tmp/wal-g \
        make deps \
     && USE_BROTLI=1 \
        USE_LIBSODIUM=1 \
-       make gp_build \
-    && rm -rf /tmp/wal-g-${WALG_VERSION}.tar.gz
+       make gp_build
 
 # pxf
 # Build pxf without tests

--- a/docker/greenplum/oraclelinux8/7/Dockerfile
+++ b/docker/greenplum/oraclelinux8/7/Dockerfile
@@ -212,8 +212,7 @@ RUN git clone ${WALG_DOWNLOAD_URL} /tmp/wal-g \
        make deps \
     && USE_BROTLI=1 \
        USE_LIBSODIUM=1 \
-       make gp_build \
-    && rm -rf /tmp/wal-g-${WALG_VERSION}.tar.gz
+       make gp_build
 
 # pxf
 # Build pxf without tests

--- a/docker/greenplum/ubuntu22.04/6/Dockerfile
+++ b/docker/greenplum/ubuntu22.04/6/Dockerfile
@@ -210,8 +210,7 @@ RUN git clone ${WALG_DOWNLOAD_URL} /tmp/wal-g \
        make deps \
     && USE_BROTLI=1 \
        USE_LIBSODIUM=1 \
-       make gp_build \
-    && rm -rf /tmp/wal-g-${WALG_VERSION}.tar.gz
+       make gp_build
 
 # pxf
 # Build pxf without tests

--- a/docker/greenplum/ubuntu22.04/7/Dockerfile
+++ b/docker/greenplum/ubuntu22.04/7/Dockerfile
@@ -191,8 +191,7 @@ RUN git clone ${WALG_DOWNLOAD_URL} /tmp/wal-g \
        make deps \
     && USE_BROTLI=1 \
        USE_LIBSODIUM=1 \
-       make gp_build \
-    && rm -rf /tmp/wal-g-${WALG_VERSION}.tar.gz
+       make gp_build
 
 # pxf
 # Build pxf without tests


### PR DESCRIPTION
* Use tags from makefile for greengage examples in compose env.
* Remove incorrect cleanup for wal-g.
* Add error example for wal-g with greengage.