### PR TITLE
Add WarehousePG 6 build support.

### DIFF
--- a/.github/workflows/build-warehousepg6.yml
+++ b/.github/workflows/build-warehousepg6.yml
@@ -1,0 +1,170 @@
+name: build-warehousepg6
+
+on: [push, pull_request]
+
+jobs:
+  build_image:
+    runs-on: ${{ matrix.platform == 'linux/arm64' && 'ubuntu-22.04-arm' || 'ubuntu-22.04' }}
+    strategy:
+      matrix:
+        warehousepg_version: ["6.27.2-WHPG"]
+        os_version: ["ubuntu22.04", "oraclelinux8"]
+        platform: ["linux/amd64", "linux/arm64"]
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Get repo tag
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+      id: vars
+      run: |
+        echo "repo_tag=$(echo ${GITHUB_REF} | cut -d'/' -f3)" >> $GITHUB_OUTPUT
+    
+    - name: Set Architecture
+      run: |
+        if [ "${{ matrix.platform }}" = "linux/amd64" ]; then
+          echo "ARCH=amd64" >> $GITHUB_ENV
+        else
+          echo "ARCH=arm64" >> $GITHUB_ENV
+        fi
+
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKEHUB_USER }}
+        password: ${{ secrets.DOCKEHUB_TOKEN }}
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GUTHUB_CR_PAT }}
+
+    - name: Build warehousepg image (Test Build)
+      run: |
+        docker buildx build \
+          -f docker/warehousepg/${OS_TAG}/6/Dockerfile \
+          --platform ${{ matrix.platform }} \
+          --build-arg GPDB_VERSION=${TAG} \
+          --build-arg REPO_BUILD_TAG=${REPO_TAG} \
+          -t warehousepg:${TAG}-${ARCH} .
+      env: 
+        TAG: ${{ matrix.warehousepg_version }}
+        OS_TAG: ${{ matrix.os_version }}
+        REPO_TAG: ${{ steps.vars.outputs.repo_tag }}
+
+    - name: Build and push platform specific images
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+      run: |
+        GHCR_BASE="ghcr.io/${GITHUB_USER}/warehousepg"
+        DH_BASE="${DOCKERHUB_USER}/warehousepg"
+
+        docker buildx build --push \
+            -f docker/warehousepg/${OS_TAG}/6/Dockerfile \
+            --platform ${{ matrix.platform }} \
+            --build-arg GPDB_VERSION=${TAG} \
+            --build-arg REPO_BUILD_TAG=${REPO_TAG} \
+            -t ${GHCR_BASE}:${TAG}-${OS_TAG}-${ARCH} \
+            -t ${GHCR_BASE}:${TAG}-${OS_TAG}-${REPO_TAG}-${ARCH} \
+            -t ${DH_BASE}:${TAG}-${OS_TAG}-${ARCH} \
+            -t ${DH_BASE}:${TAG}-${OS_TAG}-${REPO_TAG}-${ARCH} .
+      env:
+        GITHUB_USER: ${{ github.actor }}
+        GITHUB_PKG: ${{ secrets.GUTHUB_CR_PAT }}
+        DOCKERHUB_USER: ${{ secrets.DOCKEHUB_USER }}
+        DOCKERHUB_PKG: ${{ secrets.DOCKEHUB_TOKEN }}
+        TAG: ${{ matrix.warehousepg_version }}
+        OS_TAG: ${{ matrix.os_version }}
+        REPO_TAG: ${{ steps.vars.outputs.repo_tag }}
+
+  merge_manifests:
+    runs-on: ubuntu-22.04
+    needs: build_image
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    strategy:
+      matrix:
+        warehousepg_version: ["6.27.2-WHPG"]
+        os_version: ["ubuntu22.04", "oraclelinux8"]
+    steps:
+      - name: Get repo tag
+        id: vars
+        run: |
+          echo "repo_tag=$(echo ${GITHUB_REF} | cut -d'/' -f3)" >> $GITHUB_OUTPUT
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKEHUB_USER }}
+          password: ${{ secrets.DOCKEHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GUTHUB_CR_PAT }}
+
+      - name: Create and push manifest lists
+        run: |
+          GHCR_BASE="ghcr.io/${GITHUB_USER}/warehousepg"
+          DH_BASE="${DOCKERHUB_USER}/warehousepg"
+          
+          docker buildx imagetools create -t ${GHCR_BASE}:${TAG}-${OS_TAG} \
+            ${GHCR_BASE}:${TAG}-${OS_TAG}-amd64 \
+            ${GHCR_BASE}:${TAG}-${OS_TAG}-arm64
+            
+          docker buildx imagetools create -t ${DH_BASE}:${TAG}-${OS_TAG} \
+            ${DH_BASE}:${TAG}-${OS_TAG}-amd64 \
+            ${DH_BASE}:${TAG}-${OS_TAG}-arm64
+
+          docker buildx imagetools create -t ${GHCR_BASE}:${TAG}-${OS_TAG}-${REPO_TAG} \
+            ${GHCR_BASE}:${TAG}-${OS_TAG}-${REPO_TAG}-amd64 \
+            ${GHCR_BASE}:${TAG}-${OS_TAG}-${REPO_TAG}-arm64
+            
+          docker buildx imagetools create -t ${DH_BASE}:${TAG}-${OS_TAG}-${REPO_TAG} \
+            ${DH_BASE}:${TAG}-${OS_TAG}-${REPO_TAG}-amd64 \
+            ${DH_BASE}:${TAG}-${OS_TAG}-${REPO_TAG}-arm64
+
+        env:
+          GITHUB_USER: ${{ github.actor }}
+          DOCKERHUB_USER: ${{ secrets.DOCKEHUB_USER }}
+          TAG: ${{ matrix.warehousepg_version }}
+          OS_TAG: ${{ matrix.os_version }}
+          REPO_TAG: ${{ steps.vars.outputs.repo_tag }}
+
+      - name: Create and push default manifest lists (ubuntu22.04 only)
+        if: matrix.os_version == 'ubuntu22.04'
+        run: |
+          GHCR_BASE="ghcr.io/${GITHUB_USER}/warehousepg"
+          DH_BASE="${DOCKERHUB_USER}/warehousepg"
+
+          # 1. Manifest for ${TAG}
+          docker buildx imagetools create -t ${GHCR_BASE}:${TAG} \
+            ${GHCR_BASE}:${TAG}-${OS_TAG}-amd64 \
+            ${GHCR_BASE}:${TAG}-${OS_TAG}-arm64
+            
+          docker buildx imagetools create -t ${DH_BASE}:${TAG} \
+            ${DH_BASE}:${TAG}-${OS_TAG}-amd64 \
+            ${DH_BASE}:${TAG}-${OS_TAG}-arm64
+
+          # 2. Manifest for ${TAG}-${REPO_TAG}
+          docker buildx imagetools create -t ${GHCR_BASE}:${TAG}-${REPO_TAG} \
+            ${GHCR_BASE}:${TAG}-${OS_TAG}-${REPO_TAG}-amd64 \
+            ${GHCR_BASE}:${TAG}-${OS_TAG}-${REPO_TAG}-arm64
+            
+          docker buildx imagetools create -t ${DH_BASE}:${TAG}-${REPO_TAG} \
+            ${DH_BASE}:${TAG}-${OS_TAG}-${REPO_TAG}-amd64 \
+            ${DH_BASE}:${TAG}-${OS_TAG}-${REPO_TAG}-arm64
+        env:
+          GITHUB_USER: ${{ github.actor }}
+          DOCKERHUB_USER: ${{ secrets.DOCKEHUB_USER }}
+          TAG: ${{ matrix.warehousepg_version }}
+          OS_TAG: ${{ matrix.os_version }}
+          REPO_TAG: ${{ steps.vars.outputs.repo_tag }}

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ GREENGAGE_6_VERSIONS = 6.29.2
 TAG_GREENGAGE_6 ?= 6.29.2
 GREENGAGE_7_VERSIONS = 7.4.1
 TAG_GREENGAGE_7 ?= 7.4.1
+WAREHOUSEPG_6_VERSIONS = 6.27.2-WHPG
+TAG_WAREHOUSEPG_6 ?= 6.27.2-WHPG
 UBUNTU_OS_VERSION = ubuntu22.04
 OL_OS_VERSION = oraclelinux8
 UID := $(shell id -u)
@@ -53,6 +55,14 @@ build_greengage_7_ubuntu:
 build_greengage_7_oraclelinux:
 	$(call build_greengage_image_with_tag,7,$(TAG_GREENGAGE_7),$(OL_OS_VERSION))
 
+.PHONY: build_warehousepg_6_ubuntu
+build_warehousepg_6_ubuntu:
+	$(call build_warehousepg_image_with_tag,6,$(TAG_WAREHOUSEPG_6),$(UBUNTU_OS_VERSION))
+
+.PHONY: build_warehousepg_6_oraclelinux
+build_warehousepg_6_oraclelinux:
+	$(call build_warehousepg_image_with_tag,6,$(TAG_WAREHOUSEPG_6),$(OL_OS_VERSION))
+
 .PHONY: test-e2e
 test-e2e:
 	$(MAKE) -C e2e-tests test-e2e
@@ -77,3 +87,7 @@ define build_greengage_image_with_tag
 	docker buildx build -f docker/greengage/$(3)/$(1)/Dockerfile --build-arg GPDB_VERSION=$(2) -t greengage:$(2)-$(3) .
 endef
 
+define build_warehousepg_image_with_tag
+	@echo "Build WarehousePG $(1):$(2) $(3) docker image"
+	docker buildx build -f docker/warehousepg/$(3)/$(1)/Dockerfile --build-arg GPDB_VERSION=$(2) -t warehousepg:$(2)-$(3) .
+endef

--- a/README.md
+++ b/README.md
@@ -4,12 +4,14 @@
 [![build-gpdb7](https://github.com/woblerr/docker-greenplum/actions/workflows/build-gpdb7.yml/badge.svg)](https://github.com/woblerr/docker-greenplum/actions/workflows/build-gpdb7.yml)
 [![build-greengage6](https://github.com/woblerr/docker-greenplum/actions/workflows/build-greengage6.yml/badge.svg)](https://github.com/woblerr/docker-greenplum/actions/workflows/build-greengage6.yml)
 [![build-greengage7](https://github.com/woblerr/docker-greenplum/actions/workflows/build-greengage7.yml/badge.svg)](https://github.com/woblerr/docker-greenplum/actions/workflows/build-greengage7.yml)
+[![build-warehousepg6](https://github.com/woblerr/docker-greenplum/actions/workflows/build-warehousepg6.yml/badge.svg)](https://github.com/woblerr/docker-greenplum/actions/workflows/build-warehousepg6.yml)
 
 This project provides Docker images for running Greenplum Database (GPDB) and its forks in containers. It supports both single-node and multi-node deployments. The images can be used for development, testing, and learning purposes.
 
 **Supported distributions:**
 - Greenplum Database (GPDB)
-- [Greengage](https://github.com/GreengageDB/greengage) (Greenplum fork)
+- [Greengage](https://github.com/GreengageDB/greengage) (GGDB)
+- [WarehousePG](https://github.com/warehouse-pg/warehouse-pg) (WHPG)
 
 The Greenplum in docker provides the following features:
 - single-node deployment;
@@ -68,6 +70,11 @@ Greengage 7:
 |---|---|---| ---|
 | 7.4.1| `7.4.1`, `7.4.1-ubuntu22.04` | `7.4.1-oraclelinux8` | `linux/amd64`, `linux/arm64` |
 
+WarehousePG 6:
+| WarehousePG Version | Ubuntu 22.04 | Oracle Linux 8 | Platform |
+|---|---|---| ---|
+| 6.27.2-WHPG| `6.27.2-WHPG`, `6.27.2-WHPG-ubuntu22.04` | `6.27.2-WHPG-oraclelinux8` | `linux/amd64`, `linux/arm64` |
+
 ## Pull
 Change `tag` to the version you need.
 
@@ -97,6 +104,20 @@ docker pull woblerr/greengage:tag
 
 ```bash
 docker pull ghcr.io/woblerr/greengage:tag
+```
+
+**WarehousePG:**
+
+* Docker Hub:
+
+```bash
+docker pull woblerr/warehousepg:tag
+```
+
+* GitHub Registry:
+
+```bash
+docker pull ghcr.io/woblerr/warehousepg:tag
 ```
 
 ## Run
@@ -284,6 +305,18 @@ make build_greengage_6_oraclelinux TAG_GREENGAGE_6=6.29.2
 make build_greengage_7_oraclelinux TAG_GREENGAGE_7=7.4.1
 ```
 
+**WarehousePG:**
+
+For Ubuntu based images:
+```bash
+make build_warehousepg_6_ubuntu TAG_WAREHOUSEPG_6=6.27.2-WHPG
+```
+
+For Oracle Linux based images:
+```bash
+make build_warehousepg_6_oraclelinux TAG_WAREHOUSEPG_6=6.27.2-WHPG
+```
+
 **Manual build examples:**
 
 Greenplum simple manual build:
@@ -305,6 +338,16 @@ docker buildx build -f docker/greengage/oraclelinux8/6/Dockerfile -t greengage:6
 ```
 ```bash
 docker buildx build -f docker/greengage/oraclelinux8/7/Dockerfile -t greengage:7.4.1-oraclelinux8 .
+```
+
+WarehousePG simple manual build:
+```bash
+docker buildx build -f docker/warehousepg/ubuntu22.04/6/Dockerfile -t warehousepg:6.27.2-WHPG .
+```
+
+WarehousePG OracleLinux manual build:
+```bash
+docker buildx build -f docker/warehousepg/oraclelinux8/6/Dockerfile -t warehousepg:6.27.2-WHPG-oraclelinux8 .
 ```
 
 Manual build with specific component version for `linux/amd64` platform:

--- a/docker-compose/.env
+++ b/docker-compose/.env
@@ -42,4 +42,16 @@ CONFIG_FOLDER="6"
 #TAG=7.4.1-oraclelinux8
 #CONFIG_FOLDER="7"
 
+# -------------------------------------
+# WarehousePG
+# For WarehousePG 6 on Ubuntu 22.04
+#IMAGE_NAME="warehousepg"
+#TAG=6.27.2-WHPG-ubuntu22.04
+#CONFIG_FOLDER="6"
+
+# For WarehousePG 6 on Oracle Linux 8
+#IMAGE_NAME="warehousepg"
+#TAG=6.27.2-WHPG-oraclelinux8
+#CONFIG_FOLDER="6"
+
 EXPOSE_MASTER_PORT=5432

--- a/docker-compose/docker-compose.with_mirrors.yaml
+++ b/docker-compose/docker-compose.with_mirrors.yaml
@@ -23,6 +23,7 @@ services:
       - gpmon_password
     volumes:
       # - gpdb-master-data:/data
+      # - ../docs/custom_init_scripts:/docker-entrypoint-initdb.d
       - ./conf/${CONFIG_FOLDER}/gpinitsystem_config_with_mirrors:/tmp/gpinitsystem_config
       - ./conf/hostfile_gpinitsystem:/tmp/hostfile_gpinitsystem
       - ./conf/ssh/id_rsa:/home/gpadmin/.ssh/id_rsa

--- a/docker/warehousepg/oraclelinux8/6/Dockerfile
+++ b/docker/warehousepg/oraclelinux8/6/Dockerfile
@@ -1,0 +1,393 @@
+# WarehousePG - Open Source fork of Greenplum Database
+# https://github.com/warehouse-pg/warehouse-pg
+# ----
+# WAL-G should work correctly with WarehousePG
+# ----
+ARG REPO_BUILD_TAG
+ARG OL_VERSION="8"
+ARG GOLANG_VERSION="1.24.11"
+ARG GPXERCES_DOWNLOAD_URL="https://github.com/woblerr/gp-xerces/archive/refs/tags"
+ARG GPXERCES_VERSION="v3.1.2-p1"
+ARG LIBSIGAR_DOWNLOAD_URL="https://github.com/boundary/sigar"
+ARG LIBSIGAR_COMMIT_HASH="e8961a6674cc4d292e61b353b5c36bfc345434cc"
+ARG GPDB_DOWNLOAD_URL="https://github.com/warehouse-pg/warehouse-pg/archive/refs/tags"
+ARG GPDB_VERSION="6.27.2-WHPG"
+ARG DISKQUOTA_DOWNLOAD_URL="https://github.com/woblerr/diskquota/archive/refs/tags"
+ARG DISKQUOTA_VERSION="2.3.0"
+ARG PXF_DOWNLOAD_URL="https://github.com/woblerr/pxf/archive/refs/tags"
+ARG PXF_VERSION="release-6.10.1"
+ARG GPBACKUP_DOWNLOAD_URL="https://github.com/woblerr/gpbackup/archive/refs/tags"
+ARG GPBACKUP_VERSION="1.30.5"
+ARG GPBACKUP_S3_PLUGIN_DOWNLOAD_URL="https://github.com/woblerr/gpbackup-s3-plugin/archive/refs/tags"
+ARG GPBACKUP_S3_PLUGIN_VERSION="1.10.2"
+ARG GPBACKMAN_DOWNLOAD_URL="https://github.com/woblerr/gpbackman/archive/refs/tags"
+ARG GPBACKMAN_VERSION="v0.8.1"
+ARG WALG_DOWNLOAD_URL="https://github.com/wal-g/wal-g"
+# Wait new WAL-G release
+ARG WALG_VERSION="4b33c88939ce0cc23acc5f89dcf5e427c50923d9"
+ARG GOSU_VERSION="1.19"
+
+FROM oraclelinux:${OL_VERSION} AS builder
+
+ARG GPXERCES_DOWNLOAD_URL
+ARG GPXERCES_VERSION
+ARG LIBSIGAR_DOWNLOAD_URL
+ARG LIBSIGAR_COMMIT_HASH
+ARG GPDB_DOWNLOAD_URL
+ARG GPDB_VERSION
+ARG DISKQUOTA_DOWNLOAD_URL
+ARG DISKQUOTA_VERSION
+
+# Enable EPEL and Oracle CodeReady repositories
+RUN dnf -y install \
+        oracle-epel-release-el8 \
+        dnf-plugins-core \
+    && dnf config-manager --set-enabled \
+        ol8_codeready_builder \
+        ol8_developer_EPEL \
+    && dnf -y update \
+    && dnf -y install \
+        bison \
+        ccache \
+        cmake \
+        curl \
+        flex \
+        git-core \
+        gcc \
+        gcc-c++ \
+        gcc-toolset-11-gcc \
+        iputils \
+        binutils \
+        krb5-server \
+        krb5-workstation \
+        apr-devel \
+        apr-util-devel \
+        bzip2-devel \
+        libcurl-devel \
+        libevent-devel \
+        krb5-devel \
+        pam-devel \
+        perl-devel \
+        perl-ExtUtils-Embed \
+        readline-devel \
+        openssl-devel \
+        libuv-devel \
+        libxml2-devel \
+        libyaml-devel \
+        libzstd-devel \
+        zlib-devel \
+        openldap-devel \
+        libuuid-devel \
+        glibc-langpack-en \
+        glibc-locale-source \
+        net-tools \
+        ninja-build \
+        openssh-clients \
+        openssh-server \
+        openssl \
+        python2 \
+        python2-devel \
+        sudo \
+        java-11-openjdk-devel \
+        wget \
+        brotli-devel \
+        libsodium-devel \
+    && dnf clean all \
+    && rm -rf /var/cache/dnf \
+    && echo -e "/usr/local/lib\n/usr/local/lib64\n" >> /etc/ld.so.conf.d/local.conf \
+    && ldconfig
+
+# python2.7
+RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output /tmp/get-pip.py \
+    && python2 /tmp/get-pip.py \
+    && pip2 install \
+        pyyaml==5.3.1 \
+        conan==1.48.2 \
+        psutil==5.9.6 \
+        setuptools==36.6.0 \
+    && ln -s /usr/bin/python2 /usr/bin/python \
+    && rm -rf /tmp/get-pip.py
+
+# xerces-c
+RUN wget ${GPXERCES_DOWNLOAD_URL}/${GPXERCES_VERSION}.tar.gz -O /tmp/gp-xerces-${GPXERCES_VERSION}.tar.gz \
+    && mkdir -p /tmp/gp-xerces \
+    && tar -xzf /tmp/gp-xerces-${GPXERCES_VERSION}.tar.gz --strip-components=1 -C /tmp/gp-xerces \
+    && cd /tmp/gp-xerces \
+    && ./configure --prefix=/usr/local \
+    && make -j2 \
+    && make install \
+    && ldconfig \
+    && rm -rf \
+        /tmp/gp-xerces \
+        /tmp/gp-xerces-${GPXERCES_VERSION}.tar.gz
+
+# libsigar
+RUN git clone ${LIBSIGAR_DOWNLOAD_URL} /tmp/sigar \
+    && cd /tmp/sigar \
+    && git checkout ${LIBSIGAR_COMMIT_HASH} \
+    && mkdir -p /tmp/sigar/build \
+    && cd /tmp/sigar/build \
+    && cmake -DCMAKE_INSTALL_PREFIX=/usr/local .. \
+    && make -j2 \
+    && make install \
+    && ldconfig \
+    && rm -rf /tmp/sigar
+
+# warehousepg
+RUN wget ${GPDB_DOWNLOAD_URL}/${GPDB_VERSION}.tar.gz -O /tmp/gpdb-${GPDB_VERSION}.tar.gz \
+    && mkdir -p /tmp/gpdb \
+    && tar -xzf /tmp/gpdb-${GPDB_VERSION}.tar.gz --strip-components=1 -C /tmp/gpdb \
+    && cd /tmp/gpdb \
+    && echo "${GPDB_VERSION} build dev" > /tmp/gpdb/VERSION \
+    && ./configure --prefix=/usr/local/greenplum-db \
+        --enable-ic-proxy \
+        --enable-gpperfmon \
+        --with-openssl \
+        --with-perl \
+        --with-python \
+        --with-ldap \
+        --with-pam \
+        --with-libxml \
+        --with-gssapi \
+        --with-pythonsrc-ext \
+        --with-uuid=e2fs \
+    && make -j2 \
+    && make install \
+    && rm -rf \
+        /tmp/gpdb \
+        /tmp/gpdb-${GPDB_VERSION}.tar.gz
+
+# diskquota
+RUN wget ${DISKQUOTA_DOWNLOAD_URL}/${DISKQUOTA_VERSION}.tar.gz -O /tmp/diskquota-${DISKQUOTA_VERSION}.tar.gz \
+    && mkdir -p /tmp/diskquota \
+    && tar -xzf /tmp/diskquota-${DISKQUOTA_VERSION}.tar.gz --strip-components=1 -C /tmp/diskquota \
+    && mkdir -p /tmp/diskquota/build \
+    && cd /tmp/diskquota/build \
+    && cmake /tmp/diskquota \
+         -DPG_CONFIG=/usr/local/greenplum-db/bin/pg_config \
+         -DDISKQUOTA_DDL_CHANGE_CHECK=off \
+         -DCMAKE_BUILD_TYPE=Release \
+    && make install \
+    && rm -rf \
+        /tmp/diskquota \
+        /tmp/diskquota-${DISKQUOTA_VERSION}.tar.gz
+
+FROM builder AS go_builder
+ARG GOLANG_VERSION
+ARG GPBACKUP_DOWNLOAD_URL
+ARG GPBACKUP_VERSION
+ARG GPBACKUP_S3_PLUGIN_DOWNLOAD_URL
+ARG GPBACKUP_S3_PLUGIN_VERSION
+ARG GPBACKMAN_DOWNLOAD_URL
+ARG GPBACKMAN_VERSION
+ARG PXF_DOWNLOAD_URL
+ARG PXF_VERSION
+ARG WALG_DOWNLOAD_URL
+ARG WALG_VERSION
+
+RUN mkdir -p /opt/go \
+    && arch="$(uname -m)" \
+    && case "${arch}" in \
+        aarch64) dpkgArch='arm64' ;; \
+        x86_64) dpkgArch='amd64' ;; \
+        *) echo >&2 "error: unknown/unsupported architecture '${arch}'"; exit 1 ;; \
+    esac \
+    && wget https://go.dev/dl/go${GOLANG_VERSION}.linux-${dpkgArch}.tar.gz \
+    && tar -xvf go${GOLANG_VERSION}.linux-${dpkgArch}.tar.gz -C /usr/local
+
+ENV PATH="$PATH:/usr/local/go/bin"
+ENV GOPATH=/opt/go
+
+# gpbackup/gprestore
+RUN wget ${GPBACKUP_DOWNLOAD_URL}/${GPBACKUP_VERSION}.tar.gz -O /tmp/gpbackup-${GPBACKUP_VERSION}.tar.gz \
+    && mkdir -p /tmp/gpbackup /tmp/cache \
+    && tar -xzf /tmp/gpbackup-${GPBACKUP_VERSION}.tar.gz --strip-components=1 -C /tmp/gpbackup \
+    && cd /tmp/gpbackup \
+    && make depend \
+    && make build GIT_VERSION=${GPBACKUP_VERSION}
+
+# gpbackup-s3-plugin
+RUN wget ${GPBACKUP_S3_PLUGIN_DOWNLOAD_URL}/${GPBACKUP_S3_PLUGIN_VERSION}.tar.gz -O /tmp/gpbackup-s3-plugin-${GPBACKUP_S3_PLUGIN_VERSION}.tar.gz \
+    && mkdir -p /tmp/gpbackup-s3-plugin \
+    && tar -xzf /tmp/gpbackup-s3-plugin-${GPBACKUP_S3_PLUGIN_VERSION}.tar.gz --strip-components=1 -C /tmp/gpbackup-s3-plugin \
+    && cd /tmp/gpbackup-s3-plugin \
+    && make build GIT_VERSION=${GPBACKUP_S3_PLUGIN_VERSION}
+
+# gpbackman
+RUN wget ${GPBACKMAN_DOWNLOAD_URL}/${GPBACKMAN_VERSION}.tar.gz -O /tmp/gpbackman-${GPBACKMAN_VERSION}.tar.gz \
+    && mkdir -p /tmp/gpbackman \
+    && tar -xzf /tmp/gpbackman-${GPBACKMAN_VERSION}.tar.gz --strip-components=1 -C /tmp/gpbackman \
+    && cd /tmp/gpbackman \
+    && make build
+
+# wal-g
+# Don't use USE_LZO=1, there is no need to build with WAL-E compatibility
+# See https://github.com/wal-g/wal-g/issues/1412#issuecomment-1401890162
+RUN git clone ${WALG_DOWNLOAD_URL} /tmp/wal-g \
+    && cd /tmp/wal-g \
+    && git checkout ${WALG_VERSION} \
+    && USE_BROTLI=1 \
+       USE_LIBSODIUM=1 \
+       make deps \
+    && USE_BROTLI=1 \
+       USE_LIBSODIUM=1 \
+       make gp_build
+
+# pxf
+# Build pxf without tests
+# Components: external-table, cli, server
+# fdw extension is not needed for gpdb 6
+RUN wget ${PXF_DOWNLOAD_URL}/${PXF_VERSION}.tar.gz -O /tmp/pxf-${PXF_VERSION}.tar.gz \
+    && mkdir -p /tmp/pxf \
+    && tar -xzf /tmp/pxf-${PXF_VERSION}.tar.gz --strip-components=1 -C /tmp/pxf \
+    && cd /tmp/pxf \
+    && PXF_HOME=/usr/local/pxf \
+       PG_CONFIG=/usr/local/greenplum-db/bin/pg_config \
+       make -j2 -C external-table install \
+    && PXF_HOME=/usr/local/pxf \
+       PG_CONFIG=/usr/local/greenplum-db/bin/pg_config \
+       make -j2 -C cli install \
+    && PXF_HOME=/usr/local/pxf \
+       PG_CONFIG=/usr/local/greenplum-db/bin/pg_config \
+       make -j2 -C server install-server \
+    && rm -rf \
+        /tmp/pxf \
+        /tmp/pxf-${PXF_VERSION}.tar.gz
+
+FROM oraclelinux:${OL_VERSION} AS final
+
+ARG REPO_BUILD_TAG
+ARG GPDB_VERSION
+ARG GOSU_VERSION
+
+ENV TZ="Etc/UTC" \
+    GREENPLUM_USER="gpadmin" \
+    GREENPLUM_UID=1001 \
+    GREENPLUM_GROUP="gpadmin" \
+    GREENPLUM_GID=1001 \
+    GREENPLUM_DEPLOYMENT="singlenode" \
+    GREENPLUM_DATA_DIRECTORY="/data" \
+    GREENPLUM_SEG_PREFIX="gpseg" \
+    GREENPLUM_DATABASE_NAME="demo" \
+    GREENPLUM_GPPERFMON_ENABLE="false" \
+    GREENPLUM_DISKQUOTA_ENABLE="false" \
+    GREENPLUM_PXF_ENABLE="false" \
+    GREENPLUM_WALG_ENABLE="false"
+
+# Install runtime dependencies
+RUN dnf -y update \
+    && dnf -y install \
+        apr \
+        apr-util \
+        bzip2-libs \
+        libcurl \
+        libevent \
+        krb5-libs \
+        pam \
+        readline \
+        openssl-libs \
+        libuv \
+        libxml2 \
+        libyaml \
+        libzstd \
+        zlib \
+        openldap \
+        iputils \
+        krb5-server \
+        krb5-workstation \
+        libuuid \
+        openssh-clients \
+        openssh-server \
+        openssl \
+        binutils \
+        perl \
+        rsync \
+        curl \
+        sed \
+        tar \
+        zip \
+        net-tools \
+        less \
+        glibc-langpack-en \
+        glibc-locale-source \
+        iproute \
+        python2 \
+        sudo \
+        wget \
+        hostname \
+        ca-certificates \
+        tzdata \
+        java-11-openjdk-headless \
+    && dnf clean all \
+    && rm -rf /var/cache/dnf
+
+# Grab gosu for easy step-down from root
+# https://github.com/tianon/gosu/releases
+# https://github.com/tianon/gosu/blob/master/INSTALL.md
+RUN arch="$(uname -m)" \
+    && case "${arch}" in \
+            aarch64) dpkgArch='arm64' ;; \
+            x86_64) dpkgArch='amd64' ;; \
+            *) echo >&2 "error: unknown/unsupported architecture '${arch}'"; exit 1 ;; \
+        esac \
+    && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${dpkgArch}" \
+    && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${dpkgArch}.asc" \
+    # Verify the signature
+    && export GNUPGHOME="$(mktemp -d)" \
+    && gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
+    && gpgconf --kill all \
+    && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
+    && chmod +x /usr/local/bin/gosu \
+    # Verify that the binary works
+    && gosu --version \
+    && gosu nobody true
+
+RUN groupadd --gid ${GREENPLUM_GID} ${GREENPLUM_GROUP} \
+    && useradd --shell /bin/bash --uid ${GREENPLUM_UID} --gid ${GREENPLUM_GID} -m ${GREENPLUM_USER} \
+    && localedef -i en_US -f UTF-8 en_US.UTF-8 \
+    && mkdir -m 700 -p /home/${GREENPLUM_USER}/.ssh \
+    && ssh-keygen -f /home/${GREENPLUM_USER}/.ssh/id_rsa -t rsa -N "" \
+    && echo "HostKeyAlgorithms +ssh-rsa" >> /etc/ssh/sshd_config \
+    && echo "PubkeyAcceptedKeyTypes +ssh-rsa" >> /etc/ssh/sshd_config \
+    && echo "${GREENPLUM_USER} ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers \
+    && echo "source /usr/local/greenplum-db/greenplum_path.sh" > /home/${GREENPLUM_USER}/.bashrc \
+    && echo "export JAVA_HOME=/usr/lib/jvm/jre-11-openjdk" >> /home/${GREENPLUM_USER}/.bashrc \
+    && echo 'export PATH="/usr/local/pxf/bin:${PATH}"' >> /home/${GREENPLUM_USER}/.bashrc \
+    && echo "export PXF_BASE=${GREENPLUM_DATA_DIRECTORY}/pxf" >> /home/${GREENPLUM_USER}/.bashrc \
+    && mkdir -p ${GREENPLUM_DATA_DIRECTORY} \
+                ${GREENPLUM_DATA_DIRECTORY}/pxf \
+                /docker-entrypoint-initdb.d \
+    && chown -R ${GREENPLUM_USER}:${GREENPLUM_GROUP} \
+        /home/${GREENPLUM_USER}/ \
+        ${GREENPLUM_DATA_DIRECTORY} \
+        /docker-entrypoint-initdb.d \
+    && ln -s /usr/bin/python2 /usr/bin/python \
+    && unlink /etc/localtime \
+    && cp /usr/share/zoneinfo/${TZ} /etc/localtime \
+    && echo "${TZ}" > /etc/timezone
+
+COPY --from=go_builder /usr/local/greenplum-db /usr/local/greenplum-db
+COPY --from=builder \
+    /usr/local/lib/libxerces-c.so \ 
+    /usr/local/lib/libxerces-c-3.1.so \
+    /usr/local/lib/libsigar.so \
+    /usr/local/greenplum-db/lib/
+COPY --from=go_builder \
+    /opt/go/bin/gpbackup \
+    /opt/go/bin/gprestore \
+    /opt/go/bin/gpbackup_helper \
+    /usr/local/greenplum-db/bin/
+COPY --from=go_builder /opt/go/bin/gpbackup_s3_plugin /usr/local/greenplum-db/bin/gpbackup_s3_plugin
+COPY --from=go_builder /usr/local/pxf /usr/local/pxf
+COPY --from=go_builder /tmp/gpbackman/gpbackman /usr/local/greenplum-db/bin/gpbackman
+COPY --from=go_builder /tmp/wal-g/main/gp/wal-g /usr/local/greenplum-db/bin/wal-g
+COPY --chmod=755 docker/files/entrypoint.sh /entrypoint.sh
+COPY --chmod=755 docker/files/start_gpdb.sh /start_gpdb.sh
+
+LABEL \
+    org.opencontainers.image.version="${REPO_BUILD_TAG}" \
+    org.opencontainers.image.source="https://github.com/woblerr/docker-greenplum"
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/start_gpdb.sh"]

--- a/docker/warehousepg/ubuntu22.04/6/Dockerfile
+++ b/docker/warehousepg/ubuntu22.04/6/Dockerfile
@@ -1,0 +1,357 @@
+# WarehousePG - Open Source fork of Greenplum Database
+# https://github.com/warehouse-pg/warehouse-pg
+# ----
+# WAL-G should work correctly with WarehousePG
+# ----
+ARG REPO_BUILD_TAG
+ARG UBUNTU_VERSION="22.04"
+ARG GOLANG_VERSION="1.24.11"
+ARG GPXERCES_DOWNLOAD_URL="https://github.com/woblerr/gp-xerces/archive/refs/tags"
+ARG GPXERCES_VERSION="v3.1.2-p1"
+ARG LIBSIGAR_DOWNLOAD_URL="https://github.com/boundary/sigar"
+ARG LIBSIGAR_COMMIT_HASH="e8961a6674cc4d292e61b353b5c36bfc345434cc"
+ARG GPDB_DOWNLOAD_URL="https://github.com/warehouse-pg/warehouse-pg/archive/refs/tags"
+ARG GPDB_VERSION="6.27.2-WHPG"
+ARG DISKQUOTA_DOWNLOAD_URL="https://github.com/woblerr/diskquota/archive/refs/tags"
+ARG DISKQUOTA_VERSION="2.3.0"
+ARG PXF_DOWNLOAD_URL="https://github.com/woblerr/pxf/archive/refs/tags"
+ARG PXF_VERSION="release-6.10.1"
+ARG GPBACKUP_DOWNLOAD_URL="https://github.com/woblerr/gpbackup/archive/refs/tags"
+ARG GPBACKUP_VERSION="1.30.5"
+ARG GPBACKUP_S3_PLUGIN_DOWNLOAD_URL="https://github.com/woblerr/gpbackup-s3-plugin/archive/refs/tags"
+ARG GPBACKUP_S3_PLUGIN_VERSION="1.10.2"
+ARG GPBACKMAN_DOWNLOAD_URL="https://github.com/woblerr/gpbackman/archive/refs/tags"
+ARG GPBACKMAN_VERSION="v0.8.1"
+ARG WALG_DOWNLOAD_URL="https://github.com/wal-g/wal-g"
+# Wait new WAL-G release
+ARG WALG_VERSION="4b33c88939ce0cc23acc5f89dcf5e427c50923d9"
+
+FROM ubuntu:${UBUNTU_VERSION} AS builder
+
+ARG GPXERCES_DOWNLOAD_URL
+ARG GPXERCES_VERSION
+ARG LIBSIGAR_DOWNLOAD_URL
+ARG LIBSIGAR_COMMIT_HASH
+ARG GPDB_DOWNLOAD_URL
+ARG GPDB_VERSION
+ARG DISKQUOTA_DOWNLOAD_URL
+ARG DISKQUOTA_VERSION
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        bison \
+        ccache \
+        cmake \
+        curl \
+        flex \
+        git-core \
+        gcc \
+        g++ \
+        inetutils-ping \
+        binutils \
+        krb5-kdc \
+        krb5-admin-server \
+        libaprutil1-dev \
+        libapr1-dev \
+        libbz2-dev \
+        libcurl4-gnutls-dev \
+        libevent-dev \
+        libkrb5-dev \
+        libpam-dev \
+        libperl-dev \
+        libreadline-dev \
+        libssl-dev \
+        libuv1-dev \
+        libxml2-dev \
+        libyaml-dev \
+        libzstd-dev \
+        zlib1g-dev \
+        libldap-dev \
+        libossp-uuid-dev \
+        krb5-kdc \
+        krb5-admin-server \
+        locales \
+        net-tools \
+        ninja-build \
+        openssh-client \
+        openssh-server \
+        openssl \
+        python2.7 \
+        python2.7-dev \
+        git \
+        sudo \
+        openjdk-11-jdk \
+        libbrotli-dev \
+        libsodium-dev \
+    && apt-get autoremove -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && echo -e "/usr/local/lib\n/usr/local/lib64\n" >> /etc/ld.so.conf.d/local.conf \
+    && ldconfig
+
+# python2.7
+RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output /tmp/get-pip.py \
+    && python2.7 /tmp/get-pip.py \
+    && pip2.7 install \
+        pyyaml==5.3.1 \
+        conan==1.48.2 \
+        psutil==5.9.6 \
+        setuptools==36.6.0 \
+    && ln -s /usr/bin/python2.7 /usr/bin/python \
+    && rm -rf /tmp/get-pip.py
+
+# xerces-c
+RUN wget ${GPXERCES_DOWNLOAD_URL}/${GPXERCES_VERSION}.tar.gz -O /tmp/gp-xerces-${GPXERCES_VERSION}.tar.gz \
+    && mkdir -p /tmp/gp-xerces \
+    && tar -xzf /tmp/gp-xerces-${GPXERCES_VERSION}.tar.gz --strip-components=1 -C /tmp/gp-xerces \
+    && cd /tmp/gp-xerces \
+    && ./configure --prefix=/usr/local \
+    && make -j2 \
+    && make install \
+    && rm -rf \
+        /tmp/gp-xerces \
+        /tmp/gp-xerces-${GPXERCES_VERSION}.tar.gz
+
+# libsigar
+RUN git clone ${LIBSIGAR_DOWNLOAD_URL} /tmp/sigar \
+    && cd /tmp/sigar \
+    && git checkout ${LIBSIGAR_COMMIT_HASH} \
+    && mkdir -p /tmp/sigar/build \
+    && cd /tmp/sigar/build \
+    && cmake -DCMAKE_INSTALL_PREFIX=/usr/local .. \
+    && make -j2 \
+    && make install \
+    && rm -rf /tmp/sigar
+
+# warehousepg
+RUN wget ${GPDB_DOWNLOAD_URL}/${GPDB_VERSION}.tar.gz -O /tmp/gpdb-${GPDB_VERSION}.tar.gz \
+    && mkdir -p /tmp/gpdb \
+    && tar -xzf /tmp/gpdb-${GPDB_VERSION}.tar.gz --strip-components=1 -C /tmp/gpdb \
+    && cd /tmp/gpdb \
+    && echo "${GPDB_VERSION} build dev" > /tmp/gpdb/VERSION \
+    && ./configure --prefix=/usr/local/greenplum-db \
+        --enable-ic-proxy \
+        --enable-gpperfmon \
+        --with-openssl \
+        --with-perl \
+        --with-python \
+        --with-ldap \
+        --with-pam \
+        --with-libxml \
+        --with-gssapi \
+        --with-pythonsrc-ext \
+        --with-uuid=e2fs \
+    && make -j2 \
+    && make install \
+    && rm -rf \
+        /tmp/gpdb \
+        /tmp/gpdb-${GPDB_VERSION}.tar.gz
+
+# diskquota
+RUN wget ${DISKQUOTA_DOWNLOAD_URL}/${DISKQUOTA_VERSION}.tar.gz -O /tmp/diskquota-${DISKQUOTA_VERSION}.tar.gz \
+    && mkdir -p /tmp/diskquota \
+    && tar -xzf /tmp/diskquota-${DISKQUOTA_VERSION}.tar.gz --strip-components=1 -C /tmp/diskquota \
+    && mkdir -p /tmp/diskquota/build \
+    && cd /tmp/diskquota/build \
+    && cmake /tmp/diskquota \
+         -DPG_CONFIG=/usr/local/greenplum-db/bin/pg_config \
+         -DDISKQUOTA_DDL_CHANGE_CHECK=off \
+         -DCMAKE_BUILD_TYPE=Release \
+    && make install \
+    && rm -rf \
+        /tmp/diskquota \
+        /tmp/diskquota-${DISKQUOTA_VERSION}.tar.gz
+
+FROM builder AS go_builder
+ARG GOLANG_VERSION
+ARG GPBACKUP_DOWNLOAD_URL
+ARG GPBACKUP_VERSION
+ARG GPBACKUP_S3_PLUGIN_DOWNLOAD_URL
+ARG GPBACKUP_S3_PLUGIN_VERSION
+ARG GPBACKMAN_DOWNLOAD_URL
+ARG GPBACKMAN_VERSION
+ARG PXF_DOWNLOAD_URL
+ARG PXF_VERSION
+ARG WALG_DOWNLOAD_URL
+ARG WALG_VERSION
+
+RUN mkdir -p /opt/go \
+    && wget https://go.dev/dl/go${GOLANG_VERSION}.linux-$(dpkg --print-architecture).tar.gz \
+    && tar -xvf go${GOLANG_VERSION}.linux-$(dpkg --print-architecture).tar.gz -C /usr/local
+
+ENV PATH="$PATH:/usr/local/go/bin"
+ENV GOPATH=/opt/go
+
+# gpbackup/gprestore
+RUN wget ${GPBACKUP_DOWNLOAD_URL}/${GPBACKUP_VERSION}.tar.gz -O /tmp/gpbackup-${GPBACKUP_VERSION}.tar.gz \
+    && mkdir -p /tmp/gpbackup /tmp/cache \
+    && tar -xzf /tmp/gpbackup-${GPBACKUP_VERSION}.tar.gz --strip-components=1 -C /tmp/gpbackup \
+    && cd /tmp/gpbackup \
+    && make depend \
+    && make build GIT_VERSION=${GPBACKUP_VERSION}
+
+# gpbackup-s3-plugin
+RUN wget ${GPBACKUP_S3_PLUGIN_DOWNLOAD_URL}/${GPBACKUP_S3_PLUGIN_VERSION}.tar.gz -O /tmp/gpbackup-s3-plugin-${GPBACKUP_S3_PLUGIN_VERSION}.tar.gz \
+    && mkdir -p /tmp/gpbackup-s3-plugin \
+    && tar -xzf /tmp/gpbackup-s3-plugin-${GPBACKUP_S3_PLUGIN_VERSION}.tar.gz --strip-components=1 -C /tmp/gpbackup-s3-plugin \
+    && cd /tmp/gpbackup-s3-plugin \
+    && make build GIT_VERSION=${GPBACKUP_S3_PLUGIN_VERSION}
+
+# gpbackman
+RUN wget ${GPBACKMAN_DOWNLOAD_URL}/${GPBACKMAN_VERSION}.tar.gz -O /tmp/gpbackman-${GPBACKMAN_VERSION}.tar.gz \
+    && mkdir -p /tmp/gpbackman \
+    && tar -xzf /tmp/gpbackman-${GPBACKMAN_VERSION}.tar.gz --strip-components=1 -C /tmp/gpbackman \
+    && cd /tmp/gpbackman \
+    && make build
+
+# wal-g
+# Don't use USE_LZO=1, there is no need to build with WAL-E compatibility
+# See https://github.com/wal-g/wal-g/issues/1412#issuecomment-1401890162
+RUN git clone ${WALG_DOWNLOAD_URL} /tmp/wal-g \
+    && cd /tmp/wal-g \
+    && git checkout ${WALG_VERSION} \
+    && USE_BROTLI=1 \
+       USE_LIBSODIUM=1 \
+       make deps \
+    && USE_BROTLI=1 \
+       USE_LIBSODIUM=1 \
+       make gp_build
+
+# pxf
+# Build pxf without tests
+# Components: external-table, cli, server
+# fdw extension is not needed for gpdb 6
+RUN wget ${PXF_DOWNLOAD_URL}/${PXF_VERSION}.tar.gz -O /tmp/pxf-${PXF_VERSION}.tar.gz \
+    && mkdir -p /tmp/pxf \
+    && tar -xzf /tmp/pxf-${PXF_VERSION}.tar.gz --strip-components=1 -C /tmp/pxf \
+    && cd /tmp/pxf \
+    && PXF_HOME=/usr/local/pxf \
+       PG_CONFIG=/usr/local/greenplum-db/bin/pg_config \
+       make -j2 -C external-table install \
+    && PXF_HOME=/usr/local/pxf \
+       PG_CONFIG=/usr/local/greenplum-db/bin/pg_config \
+       make -j2 -C cli install \
+    && PXF_HOME=/usr/local/pxf \
+       PG_CONFIG=/usr/local/greenplum-db/bin/pg_config \
+       make -j2 -C server install-server \
+    && rm -rf \
+        /tmp/pxf \
+        /tmp/pxf-${PXF_VERSION}.tar.gz
+
+FROM ubuntu:${UBUNTU_VERSION} AS final
+
+ARG REPO_BUILD_TAG
+ARG GPDB_VERSION
+
+ENV TZ="Etc/UTC" \
+    GREENPLUM_USER="gpadmin" \
+    GREENPLUM_UID=1001 \
+    GREENPLUM_GROUP="gpadmin" \
+    GREENPLUM_GID=1001 \
+    GREENPLUM_DEPLOYMENT="singlenode" \
+    GREENPLUM_DATA_DIRECTORY="/data" \
+    GREENPLUM_SEG_PREFIX="gpseg" \
+    GREENPLUM_DATABASE_NAME="demo" \
+    GREENPLUM_GPPERFMON_ENABLE="false" \
+    GREENPLUM_DISKQUOTA_ENABLE="false" \
+    GREENPLUM_PXF_ENABLE="false" \
+    GREENPLUM_WALG_ENABLE="false"
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        libapr1 \
+        libaprutil1 \
+        libbz2-1.0 \
+        libcurl3-gnutls \
+        libcurl4 \
+        libevent-2.1-7 \
+        libkrb5-3 \
+        libpam0g \
+        libreadline8 \
+        libssl3 \
+        libuv1 \
+        libxml2 \
+        libyaml-0-2 \
+        libzstd1 \
+        zlib1g \
+        libldap-2.5-0 \
+        inetutils-ping \
+        krb5-kdc \
+        krb5-admin-server \
+        uuid-runtime \
+        openssh-client \
+        openssh-server \
+        openssl \
+        binutils \
+        perl \
+        rsync \
+        curl \
+        sed \
+        tar \
+        zip \
+        net-tools \
+        less \
+        locales \
+        iproute2 \
+        python2.7 \
+        gosu \
+        ca-certificates \
+        tzdata \
+        openjdk-11-jre \
+    && apt-get autoremove -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN groupadd --gid ${GREENPLUM_GID} ${GREENPLUM_GROUP} \
+    && useradd --shell /bin/bash --uid ${GREENPLUM_UID} --gid ${GREENPLUM_GID} -m ${GREENPLUM_USER} \
+    && locale-gen en_US.UTF-8 \
+    && mkdir -m 700 -p /home/${GREENPLUM_USER}/.ssh \
+    && ssh-keygen -f /home/${GREENPLUM_USER}/.ssh/id_rsa -t rsa -N "" \
+    && echo "HostKeyAlgorithms +ssh-rsa" >> /etc/ssh/sshd_config \
+    && echo "PubkeyAcceptedKeyTypes +ssh-rsa" >> /etc/ssh/sshd_config \
+    && echo "${GREENPLUM_USER} ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers \
+    && echo "source /usr/local/greenplum-db/greenplum_path.sh" > /home/${GREENPLUM_USER}/.bashrc \
+    && arch="$(dpkg --print-architecture)" \
+    && case "${arch}" in \
+        arm64) echo "export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-arm64" >> /home/${GREENPLUM_USER}/.bashrc ;; \
+        amd64) echo "export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64" >> /home/${GREENPLUM_USER}/.bashrc ;; \
+        *) echo >&2 "error: unknown/unsupported architecture '${arch}'"; exit 1 ;; \
+    esac \
+    && echo 'export PATH="/usr/local/pxf/bin:${PATH}"' >> /home/${GREENPLUM_USER}/.bashrc \
+    && echo "export PXF_BASE=${GREENPLUM_DATA_DIRECTORY}/pxf" >> /home/${GREENPLUM_USER}/.bashrc \
+    && mkdir -p ${GREENPLUM_DATA_DIRECTORY} \
+                ${GREENPLUM_DATA_DIRECTORY}/pxf \
+                /docker-entrypoint-initdb.d \
+    && chown -R ${GREENPLUM_USER}:${GREENPLUM_GROUP} \
+        /home/${GREENPLUM_USER}/ \
+        ${GREENPLUM_DATA_DIRECTORY} \
+        /docker-entrypoint-initdb.d \
+    && ln -s /usr/bin/python2.7 /usr/bin/python \
+    && unlink /etc/localtime \
+    && cp /usr/share/zoneinfo/${TZ} /etc/localtime \
+    && echo "${TZ}" > /etc/timezone
+
+COPY --from=go_builder /usr/local/greenplum-db /usr/local/greenplum-db
+COPY --from=builder \
+    /usr/local/lib/libxerces-c.so \ 
+    /usr/local/lib/libxerces-c-3.1.so \
+    /usr/local/lib/libsigar.so \
+    /usr/local/greenplum-db/lib/
+COPY --from=go_builder \
+    /opt/go/bin/gpbackup \
+    /opt/go/bin/gprestore \
+    /opt/go/bin/gpbackup_helper \
+    /usr/local/greenplum-db/bin/
+COPY --from=go_builder /opt/go/bin/gpbackup_s3_plugin /usr/local/greenplum-db/bin/gpbackup_s3_plugin
+COPY --from=go_builder /usr/local/pxf /usr/local/pxf
+COPY --from=go_builder /tmp/gpbackman/gpbackman /usr/local/greenplum-db/bin/gpbackman
+COPY --from=go_builder /tmp/wal-g/main/gp/wal-g /usr/local/greenplum-db/bin/wal-g
+COPY --chmod=755 docker/files/entrypoint.sh /entrypoint.sh
+COPY --chmod=755 docker/files/start_gpdb.sh /start_gpdb.sh
+
+LABEL \
+    org.opencontainers.image.version="${REPO_BUILD_TAG}" \
+    org.opencontainers.image.source="https://github.com/woblerr/docker-greenplum"
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/start_gpdb.sh"]

--- a/e2e-tests/.env
+++ b/e2e-tests/.env
@@ -1,5 +1,6 @@
 # GPDB
 # -------------------------------------
+IMAGE_NAME="greenplum"
 # For GPDB 6 on Ubuntu 22.04
 TAG=6.27.1
 CONFIG_FOLDER="6"
@@ -12,7 +13,6 @@ CONFIG_FOLDER="6"
 # For GPDB 7 on Oracle Linux 8
 #TAG=7.1.0-oraclelinux8
 #CONFIG_FOLDER="7"
-EXPOSE_MASTER_PORT=5432
 
 # GPDB RESTORE
 # -------------------------------------
@@ -28,7 +28,28 @@ RESTORE_CONFIG_FOLDER="6"
 # For GPDB 7 on Oracle Linux 8
 #RESTORE_TAG=7.1.0-oraclelinux8
 #RESTORE_CONFIG_FOLDER="7"
-# GPDB RESTORE EXPOSE PORTS
+
+# WarehousePG
+# -------------------------------------
+#IMAGE_NAME="warehousepg"
+# For WarehousePG 6 on Ubuntu 22.04
+#TAG=6.27.2-WHPG-ubuntu22.04
+#CONFIG_FOLDER="6"
+# For WarehousePG 6 on Oracle Linux 8
+#TAG=6.27.2-WHPG-oraclelinux8
+#CONFIG_FOLDER="6"
+
+# WarehousePG RESTORE
+# -------------------------------------
+# For WarehousePG 6 on Ubuntu 22.04
+#RESTORE_TAG=6.27.2-WHPG-ubuntu22.04
+#RESTORE_CONFIG_FOLDER="6"
+# For WarehousePG 6 on Oracle Linux 8
+#RESTORE_TAG=6.27.2-WHPG-oraclelinux8
+#RESTORE_CONFIG_FOLDER="6"
+
+EXPOSE_MASTER_PORT=5432
+# RESTORE EXPOSE PORTS
 EXPOSE_RESTORE_MASTER_PORT=6432
 
 # S3 MinIO

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -2,7 +2,7 @@
 
 The following architecture is used to run the tests:
 
-* Separate containers with Greenplum. This is the `docker-greenplum` image.
+* Separate containers with Greenplum (GPDB, Greengage, or WarehousePG).
 * Separate containers for MinIO and nginx. Official images [minio/minio](https://hub.docker.com/r/minio/minio), [minio/mc](https://hub.docker.com/r/minio/mc) and [nginx](https://hub.docker.com/_/nginx) are used. It's necessary for S3 compatible storage for WAL archiving and backups.
 
 ## Prerequisites
@@ -11,7 +11,7 @@ Before running tests:
 
 1. Build Greenplum docker images as described in [Build section](../README.md#build).
 
-2. Configure test environment by editing `e2e-tests/.env` file if needed (default: `GPDB 6.27.1`).
+2. Configure test environment by editing `e2e-tests/.env` file if needed (default: `GPDB 6.27.1`, other supported: `Greengage`, `WarehousePG`).
 
 3. Prepare password files as described in [Prepare section](../README.md#prepare) for Docker Compose. In tests used ssh keys from `e2e-tests/conf/ssh/` directory, so you can use them or create your own.
 
@@ -26,7 +26,7 @@ make test-e2e
 
 Primary cluster is described in `e2e-tests/docker-compose.gpdb.yml`, standby cluster is described in `e2e-tests/docker-compose.gpdb-restore.yml`, and S3 compatible storage is described in `e2e-tests/docker-compose.s3.yml`.
 
-The test validates WAL-G backup and restore functionality for Greenplum:
+The test validates WAL-G backup and restore functionality for Greenplum (works with GPDB and WarehousePG; **not supported for Greengage** due to changed database flavor):
 
 1. **Full backup test**:
    - Creates full backup on primary cluster

--- a/e2e-tests/docker-compose.gpdb-restore.yml
+++ b/e2e-tests/docker-compose.gpdb-restore.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   master-restore:
-    image: greenplum:${RESTORE_TAG}
+    image: ${IMAGE_NAME}:${RESTORE_TAG}
     container_name: master-restore
     hostname: master
     ports:
@@ -31,7 +31,7 @@ services:
       - greenplum-restore
 
   segment1-restore:
-    image: greenplum:${RESTORE_TAG}
+    image: ${IMAGE_NAME}:${RESTORE_TAG}
     container_name: segment1-restore
     hostname: segment1
     command: /start_gpdb.sh "00:primary" "01:primary"
@@ -45,7 +45,7 @@ services:
       - greenplum-restore
 
   segment2-restore:
-    image: greenplum:${RESTORE_TAG}
+    image: ${IMAGE_NAME}:${RESTORE_TAG}
     container_name: segment2-restore
     hostname: segment2
     command: /start_gpdb.sh "00:primary" "01:primary"

--- a/e2e-tests/docker-compose.gpdb.yml
+++ b/e2e-tests/docker-compose.gpdb.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   master:
-    image: greenplum:${TAG}
+    image: ${IMAGE_NAME}:${TAG}
     container_name: master
     hostname: master
     ports:
@@ -32,7 +32,7 @@ services:
       - greenplum
 
   segment1:
-    image: greenplum:${TAG}
+    image: ${IMAGE_NAME}:${TAG}
     container_name: segment1
     hostname: segment1
     command: /start_gpdb.sh "00:primary" "01:primary"
@@ -46,7 +46,7 @@ services:
       - greenplum
 
   segment2:
-    image: greenplum:${TAG}
+    image: ${IMAGE_NAME}:${TAG}
     container_name: segment2
     hostname: segment2
     command: /start_gpdb.sh "00:primary" "01:primary"


### PR DESCRIPTION
WarehousePG (https://github.com/warehouse-pg/warehouse-pg) is an open source fork of Greenplum Database.

Changes:
- Add Dockerfiles for WarehousePG 6 (Ubuntu 22.04 and Oracle Linux 8)
- Add CI workflow for building and publishing WarehousePG 6 images
- Add Makefile targets: build_warehousepg_6_ubuntu, build_warehousepg_6_oraclelinux
- Update docker-compose .env files with WarehousePG configuration
- Support IMAGE_NAME variable in e2e-tests docker-compose files
- Update documentation with WarehousePG build matrix and pull instructions

WAL-G should work correctly for WarehousePG (unlike Greengage, which has changed the database flavor in recent versions).