### PR TITLE
Add open-gpdb 6 build support. 

### DIFF
--- a/.github/workflows/build-opengpdb6.yml
+++ b/.github/workflows/build-opengpdb6.yml
@@ -1,0 +1,170 @@
+name: build-opengpdb6
+
+on: [push, pull_request]
+
+jobs:
+  build_image:
+    runs-on: ${{ matrix.platform == 'linux/arm64' && 'ubuntu-22.04-arm' || 'ubuntu-22.04' }}
+    strategy:
+      matrix:
+        greenplum_version: ["6.29.3"]
+        os_version: ["ubuntu22.04"]
+        platform: ["linux/amd64", "linux/arm64"]
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Get repo tag
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+      id: vars
+      run: |
+        echo "repo_tag=$(echo ${GITHUB_REF} | cut -d'/' -f3)" >> $GITHUB_OUTPUT
+    
+    - name: Set Architecture
+      run: |
+        if [ "${{ matrix.platform }}" = "linux/amd64" ]; then
+          echo "ARCH=amd64" >> $GITHUB_ENV
+        else
+          echo "ARCH=arm64" >> $GITHUB_ENV
+        fi
+
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKEHUB_USER }}
+        password: ${{ secrets.DOCKEHUB_TOKEN }}
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GUTHUB_CR_PAT }}
+
+    - name: Build opengpdb image (Test Build)
+      run: |
+        docker buildx build \
+          -f docker/opengpdb/${OS_TAG}/6/Dockerfile \
+          --platform ${{ matrix.platform }} \
+          --build-arg GPDB_VERSION=${TAG} \
+          --build-arg REPO_BUILD_TAG=${REPO_TAG} \
+          -t opengpdb:${TAG}-${ARCH} .
+      env: 
+        TAG: ${{ matrix.greenplum_version }}
+        OS_TAG: ${{ matrix.os_version }}
+        REPO_TAG: ${{ steps.vars.outputs.repo_tag }}
+
+    - name: Build and push platform specific images
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+      run: |
+        GHCR_BASE="ghcr.io/${GITHUB_USER}/opengpdb"
+        DH_BASE="${DOCKERHUB_USER}/opengpdb"
+
+        docker buildx build --push \
+            -f docker/opengpdb/${OS_TAG}/6/Dockerfile \
+            --platform ${{ matrix.platform }} \
+            --build-arg GPDB_VERSION=${TAG} \
+            --build-arg REPO_BUILD_TAG=${REPO_TAG} \
+            -t ${GHCR_BASE}:${TAG}-${OS_TAG}-${ARCH} \
+            -t ${GHCR_BASE}:${TAG}-${OS_TAG}-${REPO_TAG}-${ARCH} \
+            -t ${DH_BASE}:${TAG}-${OS_TAG}-${ARCH} \
+            -t ${DH_BASE}:${TAG}-${OS_TAG}-${REPO_TAG}-${ARCH} .
+      env:
+        GITHUB_USER: ${{ github.actor }}
+        GITHUB_PKG: ${{ secrets.GUTHUB_CR_PAT }}
+        DOCKERHUB_USER: ${{ secrets.DOCKEHUB_USER }}
+        DOCKERHUB_PKG: ${{ secrets.DOCKEHUB_TOKEN }}
+        TAG: ${{ matrix.greenplum_version }}
+        OS_TAG: ${{ matrix.os_version }}
+        REPO_TAG: ${{ steps.vars.outputs.repo_tag }}
+
+  merge_manifests:
+    runs-on: ubuntu-22.04
+    needs: build_image
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    strategy:
+      matrix:
+        greenplum_version: ["6.29.3"]
+        os_version: ["ubuntu22.04"]
+    steps:
+      - name: Get repo tag
+        id: vars
+        run: |
+          echo "repo_tag=$(echo ${GITHUB_REF} | cut -d'/' -f3)" >> $GITHUB_OUTPUT
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKEHUB_USER }}
+          password: ${{ secrets.DOCKEHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GUTHUB_CR_PAT }}
+
+      - name: Create and push manifest lists
+        run: |
+          GHCR_BASE="ghcr.io/${GITHUB_USER}/opengpdb"
+          DH_BASE="${DOCKERHUB_USER}/opengpdb"
+          
+          docker buildx imagetools create -t ${GHCR_BASE}:${TAG}-${OS_TAG} \
+            ${GHCR_BASE}:${TAG}-${OS_TAG}-amd64 \
+            ${GHCR_BASE}:${TAG}-${OS_TAG}-arm64
+            
+          docker buildx imagetools create -t ${DH_BASE}:${TAG}-${OS_TAG} \
+            ${DH_BASE}:${TAG}-${OS_TAG}-amd64 \
+            ${DH_BASE}:${TAG}-${OS_TAG}-arm64
+
+          docker buildx imagetools create -t ${GHCR_BASE}:${TAG}-${OS_TAG}-${REPO_TAG} \
+            ${GHCR_BASE}:${TAG}-${OS_TAG}-${REPO_TAG}-amd64 \
+            ${GHCR_BASE}:${TAG}-${OS_TAG}-${REPO_TAG}-arm64
+            
+          docker buildx imagetools create -t ${DH_BASE}:${TAG}-${OS_TAG}-${REPO_TAG} \
+            ${DH_BASE}:${TAG}-${OS_TAG}-${REPO_TAG}-amd64 \
+            ${DH_BASE}:${TAG}-${OS_TAG}-${REPO_TAG}-arm64
+
+        env:
+          GITHUB_USER: ${{ github.actor }}
+          DOCKERHUB_USER: ${{ secrets.DOCKEHUB_USER }}
+          TAG: ${{ matrix.greenplum_version }}
+          OS_TAG: ${{ matrix.os_version }}
+          REPO_TAG: ${{ steps.vars.outputs.repo_tag }}
+
+      - name: Create and push default manifest lists (ubuntu22.04 only)
+        if: matrix.os_version == 'ubuntu22.04'
+        run: |
+          GHCR_BASE="ghcr.io/${GITHUB_USER}/opengpdb"
+          DH_BASE="${DOCKERHUB_USER}/opengpdb"
+
+          # 1. Manifest for ${TAG}
+          docker buildx imagetools create -t ${GHCR_BASE}:${TAG} \
+            ${GHCR_BASE}:${TAG}-${OS_TAG}-amd64 \
+            ${GHCR_BASE}:${TAG}-${OS_TAG}-arm64
+            
+          docker buildx imagetools create -t ${DH_BASE}:${TAG} \
+            ${DH_BASE}:${TAG}-${OS_TAG}-amd64 \
+            ${DH_BASE}:${TAG}-${OS_TAG}-arm64
+
+          # 2. Manifest for ${TAG}-${REPO_TAG}
+          docker buildx imagetools create -t ${GHCR_BASE}:${TAG}-${REPO_TAG} \
+            ${GHCR_BASE}:${TAG}-${OS_TAG}-${REPO_TAG}-amd64 \
+            ${GHCR_BASE}:${TAG}-${OS_TAG}-${REPO_TAG}-arm64
+            
+          docker buildx imagetools create -t ${DH_BASE}:${TAG}-${REPO_TAG} \
+            ${DH_BASE}:${TAG}-${OS_TAG}-${REPO_TAG}-amd64 \
+            ${DH_BASE}:${TAG}-${OS_TAG}-${REPO_TAG}-arm64
+        env:
+          GITHUB_USER: ${{ github.actor }}
+          DOCKERHUB_USER: ${{ secrets.DOCKEHUB_USER }}
+          TAG: ${{ matrix.greenplum_version }}
+          OS_TAG: ${{ matrix.os_version }}
+          REPO_TAG: ${{ steps.vars.outputs.repo_tag }}

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,9 @@ test-e2e:
 test-e2e-walg:
 	$(MAKE) -C e2e-tests test-e2e-walg
 
+.PHONY: test-e2e-yezzey
+test-e2e-yezzey:
+	$(MAKE) -C e2e-tests test-e2e-yezzey
 
 define build_image
 	@echo "Build GPDB $(1):$(2) $(3) docker image"

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ WAREHOUSEPG_6_VERSIONS = 6.27.2-WHPG
 TAG_WAREHOUSEPG_6 ?= 6.27.2-WHPG
 WAREHOUSEPG_7_VERSIONS = 7.3.0-WHPG
 TAG_WAREHOUSEPG_7 ?= 7.3.0-WHPG
+OPENGPDB_6_VERSIONS = 6.29.3
+TAG_OPENGPDB_6 ?= 6.29.3
 UBUNTU_OS_VERSION = ubuntu22.04
 OL_OS_VERSION = oraclelinux8
 UID := $(shell id -u)
@@ -73,6 +75,10 @@ build_warehousepg_7_ubuntu:
 build_warehousepg_7_oraclelinux:
 	$(call build_warehousepg_image_with_tag,7,$(TAG_WAREHOUSEPG_7),$(OL_OS_VERSION))
 
+.PHONY: build_opengpdb_6_ubuntu
+build_opengpdb_6_ubuntu:
+	$(call build_opengpdb_image_with_tag,6,$(TAG_OPENGPDB_6),$(UBUNTU_OS_VERSION))
+
 .PHONY: test-e2e
 test-e2e:
 	$(MAKE) -C e2e-tests test-e2e
@@ -100,4 +106,9 @@ endef
 define build_warehousepg_image_with_tag
 	@echo "Build WarehousePG $(1):$(2) $(3) docker image"
 	docker buildx build -f docker/warehousepg/$(3)/$(1)/Dockerfile --build-arg GPDB_VERSION=$(2) -t warehousepg:$(2)-$(3) .
+endef
+
+define build_opengpdb_image_with_tag
+	@echo "Build OpenGPDB $(1):$(2) $(3) docker image"
+	docker buildx build -f docker/opengpdb/$(3)/$(1)/Dockerfile --build-arg GPDB_VERSION=$(2) -t opengpdb:$(2)-$(3) .
 endef

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This project provides Docker images for running Greenplum Database (GPDB) and it
 - Greenplum Database (GPDB)
 - [Greengage](https://github.com/GreengageDB/greengage) (GGDB)
 - [WarehousePG](https://github.com/warehouse-pg/warehouse-pg) (WHPG)
-- [open-gpdb](https://github.com/open-gpdb/gpdb)
+- [open-gpdb](https://github.com/open-gpdb/gpdb) (OpenGPDB)
 
 The Greenplum in docker provides the following features:
 - single-node deployment;

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![build-greengage7](https://github.com/woblerr/docker-greenplum/actions/workflows/build-greengage7.yml/badge.svg)](https://github.com/woblerr/docker-greenplum/actions/workflows/build-greengage7.yml)
 [![build-warehousepg6](https://github.com/woblerr/docker-greenplum/actions/workflows/build-warehousepg6.yml/badge.svg)](https://github.com/woblerr/docker-greenplum/actions/workflows/build-warehousepg6.yml)
 [![build-warehousepg7](https://github.com/woblerr/docker-greenplum/actions/workflows/build-warehousepg7.yml/badge.svg)](https://github.com/woblerr/docker-greenplum/actions/workflows/build-warehousepg7.yml)
+[![build-opengpdb6](https://github.com/woblerr/docker-greenplum/actions/workflows/build-opengpdb6.yml/badge.svg)](https://github.com/woblerr/docker-greenplum/actions/workflows/build-opengpdb6.yml)
 
 This project provides Docker images for running Greenplum Database (GPDB) and its forks in containers. It supports both single-node and multi-node deployments. The images can be used for development, testing, and learning purposes.
 
@@ -13,6 +14,7 @@ This project provides Docker images for running Greenplum Database (GPDB) and it
 - Greenplum Database (GPDB)
 - [Greengage](https://github.com/GreengageDB/greengage) (GGDB)
 - [WarehousePG](https://github.com/warehouse-pg/warehouse-pg) (WHPG)
+- [open-gpdb](https://github.com/open-gpdb/gpdb)
 
 The Greenplum in docker provides the following features:
 - single-node deployment;
@@ -81,6 +83,11 @@ WarehousePG 7:
 |---|---|---| ---|
 | 7.3.0-WHPG| `7.3.0-WHPG`, `7.3.0-WHPG-ubuntu22.04` | `7.3.0-WHPG-oraclelinux8` | `linux/amd64`, `linux/arm64` |
 
+open-gpdb 6:
+| open-gpdb Version | Ubuntu 22.04 | Oracle Linux 8 | Platform |
+|---|---|---| ---|
+| 6.29.3| `6.29.3`, `6.29.3-ubuntu22.04` | - | `linux/amd64`, `linux/arm64` |
+
 ## Pull
 Change `tag` to the version you need.
 
@@ -124,6 +131,21 @@ docker pull woblerr/warehousepg:tag
 
 ```bash
 docker pull ghcr.io/woblerr/warehousepg:tag
+```
+
+
+**open-gpdb:**
+
+* Docker Hub:
+
+```bash
+docker pull woblerr/opengpdb:tag
+```
+
+* GitHub Registry:
+
+```bash
+docker pull ghcr.io/woblerr/opengpdb:tag
 ```
 
 ## Run
@@ -329,6 +351,13 @@ make build_warehousepg_6_oraclelinux TAG_WAREHOUSEPG_6=6.27.2-WHPG
 make build_warehousepg_7_oraclelinux TAG_WAREHOUSEPG_7=7.3.0-WHPG
 ```
 
+**open-gpdb:**
+
+For Ubuntu based images:
+```bash
+make build_opengpdb_6_ubuntu TAG_OPENGPDB_6=6.29.3
+```
+
 **Manual build examples:**
 
 Greenplum simple manual build:
@@ -366,6 +395,11 @@ docker buildx build -f docker/warehousepg/oraclelinux8/6/Dockerfile -t warehouse
 ```
 ```bash
 docker buildx build -f docker/warehousepg/oraclelinux8/7/Dockerfile -t warehousepg:7.3.0-WHPG-oraclelinux8 .
+```
+
+open-gpdb simple manual build:
+```bash
+docker buildx build -f docker/opengpdb/ubuntu22.04/6/Dockerfile -t opengpdb:6.29.3 .
 ```
 
 Manual build with specific component version for `linux/amd64` platform:

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ The Greenplum in docker provides the following features:
 - custom initialization scripts;
 - WAL-G (physical backups).
 
+The open-gpdb image contains additional features:
+- Yezzey and Yproxy for data offloading to S3.
+
+
 Environment variables supported by this image:
 
 * `TZ` - container's time zone, default `Etc/UTC`;
@@ -49,44 +53,48 @@ Required environment variables:
 * `GREENPLUM_PASSWORD` - password for `${GREENPLUM_USER}` user, **required**;
 * `GREENPLUM_GPMON_PASSWORD` - password for `gpmon` user, **required** when `GREENPLUM_GPPERFMON_ENABLE` is `true`;
 
+The open-gpdb image support additional environment variables for Yezzey and Yproxy features:
+
+* `GREENPLUM_YEZZEY_ENABLE` - enable Yezzey extension and start Yproxy service for data offloading to S3, default `false`;
+
 ## Build matrix
 
 The repository contains information for the last available versions. For specific version, you can build your own image using the [Build](#build) section.
 
 Greenplum 6:
-| GPDB Version | Ubuntu 22.04 | Oracle Linux 8 | Platform |
-|---|---|---| ---|
-| 6.27.1| `6.27.1`, `6.27.1-ubuntu22.04` | `6.27.1-oraclelinux8` | `linux/amd64`, `linux/arm64` |
+| Image | GPDB Version | Ubuntu 22.04 | Oracle Linux 8 | Platform |
+|---|---|---|---| ---|
+| greenplum | 6.27.1| `6.27.1`, `6.27.1-ubuntu22.04` | `6.27.1-oraclelinux8` | `linux/amd64`, `linux/arm64` |
 
 Greenplum 7:
-| GPDB Version | Ubuntu 22.04 | Oracle Linux 8 | Platform |
-|---|---|---| ---|
-| 7.1.0| `7.1.0`, `7.1.0-ubuntu22.04` | `7.1.0-oraclelinux8` |  `linux/amd64`, `linux/arm64` |
+| Image | GPDB Version | Ubuntu 22.04 | Oracle Linux 8 | Platform |
+|---|---|---|---| ---|
+| greenplum | 7.1.0| `7.1.0`, `7.1.0-ubuntu22.04` | `7.1.0-oraclelinux8` |  `linux/amd64`, `linux/arm64` |
 
 Greengage 6:
-| Greengage Version | Ubuntu 22.04 | Oracle Linux 8 | Platform |
-|---|---|---| ---|
-| 6.29.2| `6.29.2`, `6.29.2-ubuntu22.04` | `6.29.2-oraclelinux8` | `linux/amd64`, `linux/arm64` |
+| Image | Greengage Version | Ubuntu 22.04 | Oracle Linux 8 | Platform |
+|---|---|---|---| ---|
+| greengage | 6.29.2| `6.29.2`, `6.29.2-ubuntu22.04` | `6.29.2-oraclelinux8` | `linux/amd64`, `linux/arm64` |
 
 Greengage 7:
-| Greengage Version | Ubuntu 22.04 | Oracle Linux 8 | Platform |
-|---|---|---| ---|
-| 7.4.1| `7.4.1`, `7.4.1-ubuntu22.04` | `7.4.1-oraclelinux8` | `linux/amd64`, `linux/arm64` |
+| Image | Greengage Version | Ubuntu 22.04 | Oracle Linux 8 | Platform |
+|---|---|---|---| ---|
+| greengage | 7.4.1| `7.4.1`, `7.4.1-ubuntu22.04` | `7.4.1-oraclelinux8` | `linux/amd64`, `linux/arm64` |
 
 WarehousePG 6:
-| WarehousePG Version | Ubuntu 22.04 | Oracle Linux 8 | Platform |
-|---|---|---| ---|
-| 6.27.2-WHPG| `6.27.2-WHPG`, `6.27.2-WHPG-ubuntu22.04` | `6.27.2-WHPG-oraclelinux8` | `linux/amd64`, `linux/arm64` |
+| Image | WarehousePG Version | Ubuntu 22.04 | Oracle Linux 8 | Platform |
+|---|---|---|---| ---|
+| warehousepg | 6.27.2-WHPG| `6.27.2-WHPG`, `6.27.2-WHPG-ubuntu22.04` | `6.27.2-WHPG-oraclelinux8` | `linux/amd64`, `linux/arm64` |
 
 WarehousePG 7:
-| WarehousePG Version | Ubuntu 22.04 | Oracle Linux 8 | Platform |
-|---|---|---| ---|
-| 7.3.0-WHPG| `7.3.0-WHPG`, `7.3.0-WHPG-ubuntu22.04` | `7.3.0-WHPG-oraclelinux8` | `linux/amd64`, `linux/arm64` |
+| Image | WarehousePG Version | Ubuntu 22.04 | Oracle Linux 8 | Platform |
+|---|---|---|---| ---|
+| warehousepg | 7.3.0-WHPG| `7.3.0-WHPG`, `7.3.0-WHPG-ubuntu22.04` | `7.3.0-WHPG-oraclelinux8` | `linux/amd64`, `linux/arm64` |
 
 open-gpdb 6:
-| open-gpdb Version | Ubuntu 22.04 | Oracle Linux 8 | Platform |
-|---|---|---| ---|
-| 6.29.3| `6.29.3`, `6.29.3-ubuntu22.04` | - | `linux/amd64`, `linux/arm64` |
+| Image | open-gpdb Version | Ubuntu 22.04 | Oracle Linux 8 | Platform |
+|---|---|---|---| ---|
+| opengpdb | 6.29.3| `6.29.3`, `6.29.3-ubuntu22.04` | - | `linux/amd64`, `linux/arm64` |
 
 ## Pull
 Change `tag` to the version you need.
@@ -248,6 +256,25 @@ echo "Configuring wal-g archive_command"
 USER=${GREENPLUM_USER} gpconfig -c archive_command -v "wal-g seg wal-push %p --content-id=%c --config /tmp/wal-g.yaml"
 USER=${GREENPLUM_USER} gpconfig -c archive_timeout -v 600 --skipvalidation
 USER=${GREENPLUM_USER} gpstop -u
+```
+
+#### Yezzey configuration
+
+**Note:** Yezzey is only available for open-gpdb image.
+
+When `GREENPLUM_YEZZEY_ENABLE=true`:
+- Yezzey extension is automatically configured and enabled
+- Yproxy service starts automatically
+- Requires `yproxy.yaml` configuration file mounted at `/data/yproxy.yaml` inside the container.
+
+Quick example:
+
+```bash
+docker run -p 5432:5432 \
+  -e GREENPLUM_PASSWORD=gparray \
+  -e GREENPLUM_YEZZEY_ENABLE=true \
+  -v $(pwd)/yproxy.yaml:/data/yproxy.yaml \
+  -d opengpdb:6.29.3
 ```
 
 ### Docker Compose

--- a/docker-compose/.env
+++ b/docker-compose/.env
@@ -64,4 +64,11 @@ CONFIG_FOLDER="6"
 #TAG=7.3.0-WHPG-oraclelinux8
 #CONFIG_FOLDER="7"
 
+# -------------------------------------
+# OpenGPDB
+# For OpenGPDB 6 on Ubuntu 22.04
+#IMAGE_NAME="opengpdb"
+#TAG=6.29.3-ubuntu22.04
+#CONFIG_FOLDER="6"
+
 EXPOSE_MASTER_PORT=5432

--- a/docker/files/opengpdb/start_gpdb.sh
+++ b/docker/files/opengpdb/start_gpdb.sh
@@ -29,7 +29,6 @@ file_env() {
     elif [ "${!fileVar:-}" ]; then
         val="$(< "${!fileVar}")"
     fi
-    
     export "$var"="$val"
     unset "$fileVar"
 }

--- a/docker/files/opengpdb/start_gpdb.sh
+++ b/docker/files/opengpdb/start_gpdb.sh
@@ -1,0 +1,489 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+gp_init_config_file="${GREENPLUM_DATA_DIRECTORY}/gpinitsystem_config"
+gp_init_host_file="${GREENPLUM_DATA_DIRECTORY}/hostfile_gpinitsystem"
+gp_custom_init_dir="/docker-entrypoint-initdb.d"
+gp_master_dir_name="master"
+gp_hostname=$(hostname)
+
+error_and_exit() {
+    echo "ERROR - $1"
+    exit 1
+}
+
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+    local var="$1"
+    local fileVar="${var}_FILE"
+    local def="${2:-}"
+    if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+        error_and_exit "Both $var and $fileVar are set (but are exclusive)"
+    fi
+    local val="$def"
+    if [ "${!var:-}" ]; then
+        val="${!var}"
+    elif [ "${!fileVar:-}" ]; then
+        val="$(< "${!fileVar}")"
+    fi
+    
+    export "$var"="$val"
+    unset "$fileVar"
+}
+
+setup_version_config() {
+    source "/home/${GREENPLUM_USER}/.bashrc"
+    # Get gpdb major version from gpinitsystem command.
+    # It's necessary to know the version to operate with the correct directories.
+    # Example: gpinitsystem 6.26.4 build dev
+    gp_major_version=$(gpinitsystem --version | cut -d' ' -f2 | cut -d'.' -f1)
+    case ${gp_major_version} in
+      "6")
+        gp_log_dir="pg_log"
+        gp_master_data_dir_prefix="MASTER"
+        ;;
+      "7")
+        gp_log_dir="log"
+        gp_master_data_dir_prefix="COORDINATOR"
+        ;;
+      *)
+        error_and_exit "Invalid Greenplum version: ${gp_major_version}"
+        ;;
+    esac
+}
+
+create_directory() {
+    local dir=$1
+    if [ ! -d "${dir}" ]; then
+        echo "INFO - Creating directory: ${dir}"
+        mkdir -p "${dir}"
+    fi
+}
+
+setup_master() {
+    echo "export ${gp_master_data_dir_prefix}_DATA_DIRECTORY=${GREENPLUM_DATA_DIRECTORY}/${gp_master_dir_name}/${GREENPLUM_SEG_PREFIX}-1" >> ~/.bashrc
+    source "/home/${GREENPLUM_USER}/.bashrc"
+    create_directory "${GREENPLUM_DATA_DIRECTORY}/${gp_master_dir_name}"
+}
+
+setup_segments() {
+    local segment_num=$1
+    local segment_type=$2
+    create_directory "${GREENPLUM_DATA_DIRECTORY}/${segment_num}/${segment_type}"
+}
+
+# Resolve issue for GPDB 7 with mounted authorized_keys in docker
+# In GPDB 7, gpssh-exkeys use rsync to copy the authorized_keys
+# and we get error:
+#   rsync: rename "/home/gpadmin/.ssh/.authorized_keys.wiHHYt" -> "authorized_keys": Device or resource busy (16)
+# For GPDB 6 the problem is not reproduced, because the scp command is used.
+setup_segment_authorized_keys(){
+    if [ -f /tmp/authorized_keys ]; then
+        echo "INFO - Copy authorized_keys to /home/${GREENPLUM_USER}/.ssh/authorized_keys"
+        cp /tmp/authorized_keys /home/${GREENPLUM_USER}/.ssh/authorized_keys
+        chmod 600 /home/${GREENPLUM_USER}/.ssh/authorized_keys
+    fi
+}
+
+verify_prerequisites() {
+    file_env "GREENPLUM_PASSWORD"
+
+    check_required_var "GREENPLUM_DATA_DIRECTORY" "${GREENPLUM_DATA_DIRECTORY}"
+    check_required_var "GREENPLUM_PASSWORD" "${GREENPLUM_PASSWORD}"
+    # Check gpperfmon password only if gpperfmon is enabled for GPDB6 master deployment
+    if is_gpperfmon_enabled; then
+        file_env "GREENPLUM_GPMON_PASSWORD"
+        check_required_var "GREENPLUM_GPMON_PASSWORD" "${GREENPLUM_GPMON_PASSWORD}"
+    fi
+}
+
+is_gpperfmon_enabled() {
+    [[ "${GREENPLUM_GPPERFMON_ENABLE}" == "true" && 
+       "${gp_major_version}" == "6" && 
+       "${GREENPLUM_DEPLOYMENT}" == "master" ]]
+}
+
+is_yproxy_enabled() {
+    # Yproxy is required when Yezzey is enabled
+    [[ "${GREENPLUM_YEZZEY_ENABLE}" == "true" ]]
+}
+
+check_required_var() {
+    local var_name=$1
+    local var_value=$2
+    if [ -z "${var_value}" ]; then
+        error_and_exit "${var_name} variable is not set!"
+    fi
+}
+
+setup_gpinitsystem_config(){
+    if [ -f /tmp/gpinitsystem_config ]; then
+        echo "INFO - Copy gpinitsystem_config to ${gp_init_config_file}"
+        cp /tmp/gpinitsystem_config "${gp_init_config_file}"
+    fi
+}
+
+generate_gpinitsystem_config() {
+    if [ ! -f "${gp_init_config_file}" ] ; then
+        cat > "${gp_init_config_file}" <<EOF
+ARRAY_NAME="Greenplum in docker"
+DATABASE_NAME=${GREENPLUM_DATABASE_NAME}
+SEG_PREFIX=${GREENPLUM_SEG_PREFIX}
+PORT_BASE=6000
+${gp_master_data_dir_prefix}_HOSTNAME=${gp_hostname}
+${gp_master_data_dir_prefix}_DIRECTORY=${GREENPLUM_DATA_DIRECTORY}/${gp_master_dir_name}
+${gp_master_data_dir_prefix}_PORT=5432
+TRUSTED_SHELL=ssh
+CHECK_POINT_SEGMENTS=8
+ENCODING=UNICODE
+MACHINE_LIST_FILE=${gp_init_host_file}
+declare -a DATA_DIRECTORY=(${GREENPLUM_DATA_DIRECTORY}/00/primary ${GREENPLUM_DATA_DIRECTORY}/01/primary)
+EOF
+    fi
+}
+
+setup_hostfile_gpinitsystem(){
+    if [ -f /tmp/hostfile_gpinitsystem ]; then
+        echo "INFO - Copy hostfile_gpinitsystem to ${gp_init_host_file}"
+        cp /tmp/hostfile_gpinitsystem "${gp_init_host_file}"
+    fi
+}
+
+generate_hostfile_gpinitsystem() {
+    if [ ! -f "${gp_init_host_file}" ] ; then
+        echo "${gp_hostname}" > ${gp_init_host_file}
+    fi
+}
+
+execute_custom_init_scripts() {
+    local script
+    if [ -d "${gp_custom_init_dir}" ] && [ -n "$(ls -A ${gp_custom_init_dir})" ]; then
+        echo "INFO - Executing custom initialization scripts"
+        for script in "${gp_custom_init_dir}"/*; do
+            case "${script}" in
+                *.sh)
+                    if [ -x "${script}" ]; then
+                        echo "INFO - Executing shell script: ${script}"
+                        "${script}"
+                    else
+                        echo "INFO - Sourcing shell script: ${script}"
+                        source "${script}"
+                    fi
+                    ;;
+                *.sql)
+                    echo "INFO - Executing SQL script: ${script}"
+                    psql -v ON_ERROR_STOP=1  --no-psqlrc -U "${GREENPLUM_USER}" -d "${GREENPLUM_DATABASE_NAME}" -f "${script}"
+                    ;;
+                *)
+                    echo "INFO - Ignoring: ${script}"
+                    ;;
+            esac
+        done
+        echo "INFO - Finished executing custom initialization scripts"
+    fi
+}
+
+setup_yproxy_config() {
+    local yproxy_config="${GREENPLUM_DATA_DIRECTORY}/yproxy.yaml"
+    local yproxy_socket="/tmp/yproxy.sock"
+    if [ ! -f "${yproxy_config}" ]; then
+        error_and_exit "yproxy config not found at ${yproxy_config}. Please mount your yproxy.yaml configuration file to ${yproxy_config}"
+    fi
+    echo "INFO - Using yproxy config at ${yproxy_config}"
+    export YPROXY_CONFIG="${yproxy_config}"
+    export YPROXY_SOCKET="${yproxy_socket}"
+}
+
+start_yproxy() {
+    # Check if yproxy command is available
+    if ! command -v yproxy &> /dev/null; then
+        error_and_exit "yproxy command not found. This feature is only available in OpenGPDB images."
+    fi
+    local yproxy_config="${YPROXY_CONFIG}"
+    local yproxy_socket="${YPROXY_SOCKET}"
+    if [ -S "${yproxy_socket}" ]; then
+        echo "INFO - yproxy socket already exists at ${yproxy_socket}, checking if service is running"
+        if nc -U -z "${yproxy_socket}" 2>/dev/null; then
+            echo "INFO - yproxy is already running"
+            return 0
+        else
+            echo "INFO - Removing stale socket ${yproxy_socket}"
+            rm -f "${yproxy_socket}"
+        fi
+    fi
+    echo "INFO - Starting yproxy with config ${yproxy_config}"
+    yproxy --config "${yproxy_config}" >> "${GREENPLUM_DATA_DIRECTORY}/yproxy.log" 2>&1 &
+    local yproxy_pid=$!
+    # Wait for socket to be created (max 30 seconds)
+    local wait_time=0
+    while [ ! -S "${yproxy_socket}" ] && [ ${wait_time} -lt 30 ]; do
+        sleep 1
+        wait_time=$((wait_time + 1))
+    done
+    if [ -S "${yproxy_socket}" ]; then
+        echo "INFO - yproxy started successfully (PID: ${yproxy_pid})"
+        echo "${yproxy_pid}" > "${GREENPLUM_DATA_DIRECTORY}/yproxy.pid"
+    else
+        error_and_exit "Failed to start yproxy, socket not created"
+    fi
+}
+
+stop_yproxy() {
+    local yproxy_pid_file="${GREENPLUM_DATA_DIRECTORY}/yproxy.pid"
+    if [ -f "${yproxy_pid_file}" ]; then
+        local yproxy_pid=$(cat "${yproxy_pid_file}")
+        if kill -0 "${yproxy_pid}" 2>/dev/null; then
+            echo "INFO - Stopping yproxy (PID: ${yproxy_pid})"
+            kill "${yproxy_pid}"
+            rm -f "${yproxy_pid_file}"
+        fi
+    fi
+    rm -f "${YPROXY_SOCKET}"
+}
+
+initialize_and_start_gpdb_segments() {
+    local end_flag=""
+    local arg segment_num segment_type
+    source "/home/${GREENPLUM_USER}/.bashrc"
+    echo "INFO - Initializing segment host"
+    if [ $# -eq 0 ]; then
+        error_and_exit "No segment specifications provided"
+    fi
+    for arg in "$@"; do
+        if [[ ! "$arg" =~ ^[0-9]+:(primary|mirror)$ ]]; then
+            error_and_exit "Invalid segment specification format: $arg, expected format: NUMBER:TYPE"
+        fi
+        IFS=':' read -r segment_num segment_type <<< "$arg"
+        setup_segments "${segment_num}" "${segment_type}"
+    done
+    # Start yproxy if enabled
+    if is_yproxy_enabled; then
+        setup_yproxy_config
+        start_yproxy
+    fi
+    trap "if is_yproxy_enabled; then \
+            echo 'INFO - Stop yproxy'; \
+            stop_yproxy; \
+        fi; \
+        echo 'INFO - Shutdown segment host' && end_flag=1" TERM INT
+    # Keep container running
+    while [ "${end_flag}" == '' ]; do
+        sleep 1
+    done
+}
+
+initialize_and_start_gpdb() {
+    local pg_hba="${GREENPLUM_DATA_DIRECTORY}/${gp_master_dir_name}/${GREENPLUM_SEG_PREFIX}-1/pg_hba.conf"
+    local pxf_env="${PXF_BASE}/conf/pxf-env.sh"
+    local end_flag=""
+    local gpdb_already_exists_flag=false
+
+    # Scan and add host keys
+    for host in $(cat ${gp_init_host_file}); do
+        ssh-keyscan -t rsa $host >> /home/${GREENPLUM_USER}/.ssh/known_hosts 2>/dev/null
+    done
+    chmod 644 /home/${GREENPLUM_USER}/.ssh/known_hosts
+
+    # Fetch rsa ssh keys from hosts
+    gpssh-exkeys -f "${gp_init_host_file}"
+
+    if [ -f "${pg_hba}" ]; then
+        gpdb_already_exists_flag=true
+        # In case when we use persistent volume and data catalog is already exists
+        # we need to configure .pgpass file for gpperfmon before starting GPDB
+        # Otherwise, we get error:
+        # 3rd party error log: Performance Monitor - failed to connect to gpperfmon database: fe_sendauth: no password supplied
+        if is_gpperfmon_enabled; then
+            echo "*:5432:gpperfmon:gpmon:${GREENPLUM_GPMON_PASSWORD}" > /home/${GREENPLUM_USER}/.pgpass
+            chmod 600 /home/${GREENPLUM_USER}/.pgpass
+        fi
+	    echo 'INFO - Start GPDB'
+	    gpstart -a
+    else
+        # Init gpdb
+        echo "INFO - Initialize GPDB"
+        if [ "${gp_major_version}" == "6" ]; then
+            gpinitsystem -e ${GREENPLUM_PASSWORD} -ac ${gp_init_config_file} --ignore-warnings
+        else
+            gpinitsystem -e ${GREENPLUM_PASSWORD} -ac ${gp_init_config_file}
+        fi
+        # Enable gpperfmon
+        if is_gpperfmon_enabled; then
+            echo "INFO - Enable gpperfmon"
+            USER=${GREENPLUM_USER} gpperfmon_install --enable --password "${GREENPLUM_GPMON_PASSWORD}" --port 5432
+            # Necessary to correct start gpsmon process. Without this, in some cases, the process is not started
+            echo "verbose=1" >> ${GREENPLUM_DATA_DIRECTORY}/${gp_master_dir_name}/${GREENPLUM_SEG_PREFIX}-1/gpperfmon/conf/gpperfmon.conf
+            # Configure  gp_interconnect_type  to TCP
+            # Without this in docker the error for gpsmon could be raised:
+            # "send dummy packet failed, sendto failed: Cannot assign requested address",,,,,,,0,,"ic_udpifc.c",7020,
+            echo "INFO -  USER=${GREENPLUM_USER} gpconfig -c gp_interconnect_type -v tcp"
+            USER=${GREENPLUM_USER} gpconfig -c gp_interconnect_type -v tcp
+        fi
+        if [ "${GREENPLUM_DISKQUOTA_ENABLE}" == "true" ]; then
+            echo "INFO - Enable diskquota"
+            echo "INFO - createdb diskquota"
+            createdb "diskquota"
+            # Get current shared_preload_libraries value
+            echo "INFO - psql template1 -t -c \"SHOW shared_preload_libraries\" | xargs"
+            gp_shared_preload_libraries=$(psql template1 -t -c "SHOW shared_preload_libraries" | xargs)
+            # Get available diskquota version
+            echo "INFO - psql template1 -t -c \"SELECT default_version FROM pg_available_extensions WHERE name = 'diskquota'\" | xargs"
+            gp_diskquota_version=$(psql template1 -t -c "SELECT default_version FROM pg_available_extensions WHERE name = 'diskquota'" | xargs)
+            # Add diskquota to shared_preload_libraries
+            if [ -z "${gp_shared_preload_libraries}" ]; then
+                echo "INFO - gpconfig -c shared_preload_libraries -v \"diskquota-${gp_diskquota_version}\""
+                USER=${GREENPLUM_USER} gpconfig -c shared_preload_libraries -v "diskquota-${gp_diskquota_version}"
+            else
+                echo "INFO - gpconfig -c shared_preload_libraries -v \"'$gp_shared_preload_libraries,diskquota-${gp_diskquota_version}'\""
+                USER=${GREENPLUM_USER} gpconfig -c shared_preload_libraries -v "'$gp_shared_preload_libraries,diskquota-${gp_diskquota_version}'"
+            fi
+        fi
+        if [ "${GREENPLUM_WALG_ENABLE}" == "true" ]; then
+            echo "INFO - Set parameters for WAL archiving"
+            echo "INFO - gpconfig -c archive_mode -v on"
+            USER=${GREENPLUM_USER} gpconfig -c archive_mode -v on
+            echo "INFO - gpconfig -c archive_command -v '/bin/true'"
+            # Set archive_command to /bin/true because there is no storage for WAL specified
+            # This is necessary to avoid errors
+            # Use init script to set actual archive_command
+            USER=${GREENPLUM_USER} gpconfig -c archive_command -v "'/bin/true'"
+            if [ "${gp_major_version}" == "6" ]; then
+                echo "INFO - gpconfig -c wal_level -v archive"
+                USER=${GREENPLUM_USER} gpconfig -c wal_level -v archive --skipvalidation
+                echo "INFO - psql ${GREENPLUM_DATABASE_NAME} -t -c \"CREATE EXTENSION IF NOT EXISTS gp_pitr;\" | xargs"
+                psql ${GREENPLUM_DATABASE_NAME} -t -c "CREATE EXTENSION IF NOT EXISTS gp_pitr;" | xargs
+            else
+                echo "INFO - gpconfig -c wal_level -v replica"
+                USER=${GREENPLUM_USER} gpconfig -c wal_level -v replica --skipvalidation
+            fi
+        fi
+        if [ "${GREENPLUM_YEZZEY_ENABLE}" == "true" ]; then
+            echo "INFO - Enable yezzey"
+            # Check if yezzey extension is available
+            if ! psql template1 -t -c "SELECT 1 FROM pg_available_extensions WHERE name = 'yezzey'" 2>/dev/null | grep -q 1; then
+                error_and_exit "yezzey extension not available. This feature is only available in OpenGPDB images."
+            fi
+            # Get current shared_preload_libraries value
+            echo "INFO - psql template1 -t -c \"SHOW shared_preload_libraries\" | xargs"
+            gp_shared_preload_libraries=$(psql template1 -t -c "SHOW shared_preload_libraries" | xargs)
+            # Configure yezzey parameters
+            # Disable GPG encryption for data offloaded to S3
+            echo "INFO - gpconfig -c yezzey.use_gpg_crypto -v \"false\""
+            USER=${GREENPLUM_USER} gpconfig -c yezzey.use_gpg_crypto -v "false"
+            # Enable OTM (Offload Table Metadata) to track offloaded table segments
+            echo "INFO - gpconfig -c yezzey.use_otm_feature -v \"true\""
+            USER=${GREENPLUM_USER} gpconfig -c yezzey.use_otm_feature -v "true"
+            # Add yezzey to shared_preload_libraries
+            if [ -z "${gp_shared_preload_libraries}" ]; then
+                echo "INFO - gpconfig -c shared_preload_libraries -v \"yezzey\""
+                USER=${GREENPLUM_USER} gpconfig -c shared_preload_libraries -v "yezzey"
+            else
+                echo "INFO - gpconfig -c shared_preload_libraries -v \"'$gp_shared_preload_libraries,yezzey'\""
+                USER=${GREENPLUM_USER} gpconfig -c shared_preload_libraries -v "'$gp_shared_preload_libraries,yezzey'"
+            fi
+        fi
+        # Configure pg_hba
+        echo "INFO - Configure pg_hba.conf"
+        {
+            echo "host all all 0.0.0.0/0 md5"
+            echo "host all all ::0/0 md5"
+        } >> "${pg_hba}"
+        echo "INFO - Restart GPDB"
+        gpstop -ar
+        sleep 10
+    fi
+    # If db name is set and diskquota is enabled, create extension and init table size table
+    if [ "${GREENPLUM_DISKQUOTA_ENABLE}" == "true" ] && [ -n "${GREENPLUM_DATABASE_NAME:-}" ]; then
+        echo "INFO - psql ${GREENPLUM_DATABASE_NAME} -t -c \"CREATE EXTENSION IF NOT EXISTS diskquota;\" | xargs"
+        psql ${GREENPLUM_DATABASE_NAME} -t -c "CREATE EXTENSION IF NOT EXISTS diskquota;" | xargs
+        echo "INFO - psql ${GREENPLUM_DATABASE_NAME} -t -c \"SELECT diskquota.init_table_size_table();\" | xargs"
+        psql ${GREENPLUM_DATABASE_NAME} -t -c "SELECT diskquota.init_table_size_table();" | xargs
+    fi
+    # If db name is set and yezzey is enabled, create extension
+    if [ "${GREENPLUM_YEZZEY_ENABLE}" == "true" ] && [ -n "${GREENPLUM_DATABASE_NAME:-}" ]; then
+        # Check if yezzey extension is available
+        if ! psql template1 -t -c "SELECT 1 FROM pg_available_extensions WHERE name = 'yezzey'" 2>/dev/null | grep -q 1; then
+            error_and_exit "yezzey extension not available. This feature is only available in OpenGPDB images."
+        fi
+        echo "INFO - psql ${GREENPLUM_DATABASE_NAME} -t -c \"CREATE EXTENSION IF NOT EXISTS yezzey;\" | xargs"
+        psql ${GREENPLUM_DATABASE_NAME} -t -c "CREATE EXTENSION IF NOT EXISTS yezzey;" | xargs
+    fi
+    # Enable PXF
+    if [ ${GREENPLUM_PXF_ENABLE} == "true" ]; then
+        if [ ! -f "${pxf_env}" ]; then
+            echo "INFO - Enable PXF"
+            pxf cluster prepare
+            pxf cluster register
+            echo "INFO - psql ${GREENPLUM_DATABASE_NAME} -t -c \"CREATE EXTENSION IF NOT EXISTS pxf;\" | xargs"
+            psql ${GREENPLUM_DATABASE_NAME} -t -c "CREATE EXTENSION IF NOT EXISTS pxf;" | xargs
+            echo "INFO - configure JVM options for PXF"
+            # Minimaze JVM memory for PXF.
+            # For docker default is too big.
+            echo 'PXF_JVM_OPTS="-Xmx512m -Xms256m"' >> ${pxf_env}
+            pxf cluster sync
+        fi
+        echo "INFO - pxf cluster start"
+        pxf cluster start
+        sleep 10
+    fi
+    # Start yproxy if enabled
+    if is_yproxy_enabled; then
+        setup_yproxy_config
+        start_yproxy
+    fi
+    # Monitor logs
+    trap "kill %1; \
+        if [ ${GREENPLUM_PXF_ENABLE} == 'true' ] && [ -f '${pxf_env}' ]; then \
+            echo 'INFO - Stop PXF cluster'; \
+            pxf cluster stop; \
+        fi; \
+        if is_yproxy_enabled; then \
+            echo 'INFO - Stop yproxy'; \
+            stop_yproxy; \
+        fi; \
+        gpstop -a -M fast && end_flag=1" INT TERM
+    tail -f $(ls ${GREENPLUM_DATA_DIRECTORY}/${gp_master_dir_name}/${GREENPLUM_SEG_PREFIX}-1/${gp_log_dir}/gpdb-* | tail -n1) &
+    # Execute custom init scripts.
+    if [ "${gpdb_already_exists_flag}" == false ]; then
+        echo "INFO - Execute custom init scripts"
+        execute_custom_init_scripts
+    fi
+    #trap
+    while [ "${end_flag}" == '' ]; do
+        sleep 1
+    done
+}
+
+case ${GREENPLUM_DEPLOYMENT} in
+    "singlenode")
+        setup_version_config
+        verify_prerequisites
+        setup_master
+        setup_segments "00" "primary"
+        setup_segments "01" "primary"
+        setup_gpinitsystem_config
+        generate_gpinitsystem_config
+        setup_hostfile_gpinitsystem
+        generate_hostfile_gpinitsystem
+        initialize_and_start_gpdb
+        ;;
+    "master")
+        setup_version_config
+        verify_prerequisites
+        setup_master
+        setup_gpinitsystem_config
+        generate_gpinitsystem_config
+        setup_hostfile_gpinitsystem
+        initialize_and_start_gpdb
+        ;;
+    "segment")
+        setup_segment_authorized_keys
+        initialize_and_start_gpdb_segments "$@"
+        ;;
+    *)
+        error_and_exit "Invalid deployment mode: ${GREENPLUM_DEPLOYMENT}"
+        ;;
+esac

--- a/docker/files/start_gpdb.sh
+++ b/docker/files/start_gpdb.sh
@@ -29,7 +29,6 @@ file_env() {
     elif [ "${!fileVar:-}" ]; then
         val="$(< "${!fileVar}")"
     fi
-    
     export "$var"="$val"
     unset "$fileVar"
 }

--- a/docker/opengpdb/ubuntu22.04/6/Dockerfile
+++ b/docker/opengpdb/ubuntu22.04/6/Dockerfile
@@ -20,6 +20,11 @@ ARG GPBACKMAN_VERSION="v0.8.1"
 ARG WALG_DOWNLOAD_URL="https://github.com/wal-g/wal-g"
 # Wait new WAL-G release
 ARG WALG_VERSION="4b33c88939ce0cc23acc5f89dcf5e427c50923d9"
+ARG YPROXY_DOWNLOAD_URL="https://github.com/open-gpdb/yproxy/archive/refs/tags"
+ARG YPROXY_VERSION="1.7.2"
+ARG YEZZEY_DOWNLOAD_URL="https://github.com/open-gpdb/yezzey"
+# Wait new yezzey release
+ARG YEZZEY_VERSION="e32a6eb9bf711d23d80c1b6d9cf5c47a6778b0b5"
 
 FROM ubuntu:${UBUNTU_VERSION} AS builder
 
@@ -31,6 +36,10 @@ ARG GPDB_DOWNLOAD_URL
 ARG GPDB_VERSION
 ARG DISKQUOTA_DOWNLOAD_URL
 ARG DISKQUOTA_VERSION
+ARG YEZZEY_DOWNLOAD_URL
+ARG YEZZEY_VERSION
+ARG YPROXY_DOWNLOAD_URL
+ARG YPROXY_VERSION
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y \
@@ -78,6 +87,9 @@ RUN apt-get update \
         openjdk-11-jdk \
         libbrotli-dev \
         libsodium-dev \
+        libprotobuf-c-dev \
+        protobuf-c-compiler \
+        libgpgme-dev \
     && apt-get autoremove -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
@@ -124,6 +136,14 @@ RUN wget ${GPDB_DOWNLOAD_URL}/${GPDB_VERSION}.tar.gz -O /tmp/gpdb-${GPDB_VERSION
     && tar -xzf /tmp/gpdb-${GPDB_VERSION}.tar.gz --strip-components=1 -C /tmp/gpdb \
     && cd /tmp/gpdb \
     && echo "${GPDB_VERSION} build dev" > /tmp/gpdb/VERSION \
+    # Clone yezzey into gpcontrib before building GPDB
+    && git clone ${YEZZEY_DOWNLOAD_URL} gpcontrib/yezzey --depth 1 \
+    && cd gpcontrib/yezzey \
+    && git checkout ${YEZZEY_VERSION} \
+    && cd /tmp/gpdb \
+    # Remove 'trusted' parameter from control file for compatibility
+    # This prevents potential security issues with untrusted extension loading
+    && sed -i '/^trusted/d' gpcontrib/yezzey/yezzey.control \
     && ./configure --prefix=/usr/local/greenplum-db \
         --enable-ic-proxy \
         --enable-gpperfmon \
@@ -139,8 +159,6 @@ RUN wget ${GPDB_DOWNLOAD_URL}/${GPDB_VERSION}.tar.gz -O /tmp/gpdb-${GPDB_VERSION
         # See https://github.com/open-gpdb/gpdb/commit/654c51834f820c716f41999751a7cb242bd66775
         # and https://yandex.cloud/en/docs/managed-postgresql/tutorials/glibc-collation-issues
         --without-mdblocales \
-        # Enable later
-        --disable-yezzey \
     && make -j2 \
     && make install \
     && rm -rf \
@@ -180,6 +198,8 @@ ARG PXF_DOWNLOAD_URL
 ARG PXF_VERSION
 ARG WALG_DOWNLOAD_URL
 ARG WALG_VERSION
+ARG YPROXY_DOWNLOAD_URL
+ARG YPROXY_VERSION
 
 RUN mkdir -p /opt/go \
     && wget https://go.dev/dl/go${GOLANG_VERSION}.linux-$(dpkg --print-architecture).tar.gz \
@@ -223,6 +243,13 @@ RUN git clone ${WALG_DOWNLOAD_URL} /tmp/wal-g \
        USE_LIBSODIUM=1 \
        make gp_build
 
+# yproxy
+RUN wget ${YPROXY_DOWNLOAD_URL}/${YPROXY_VERSION}.tar.gz -O /tmp/yproxy-${YPROXY_VERSION}.tar.gz \
+    && mkdir -p /tmp/yproxy \
+    && tar -xzf /tmp/yproxy-${YPROXY_VERSION}.tar.gz --strip-components=1 -C /tmp/yproxy \
+    && cd /tmp/yproxy \
+    && make build
+
 # pxf
 # Build pxf without tests
 # Components: external-table, cli, server
@@ -261,7 +288,8 @@ ENV TZ="Etc/UTC" \
     GREENPLUM_GPPERFMON_ENABLE="false" \
     GREENPLUM_DISKQUOTA_ENABLE="false" \
     GREENPLUM_PXF_ENABLE="false" \
-    GREENPLUM_WALG_ENABLE="false"
+    GREENPLUM_WALG_ENABLE="false" \
+    GREENPLUM_YEZZEY_ENABLE="false"
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y \
@@ -351,9 +379,11 @@ COPY --from=go_builder \
 COPY --from=go_builder /opt/go/bin/gpbackup_s3_plugin /usr/local/greenplum-db/bin/gpbackup_s3_plugin
 COPY --from=go_builder /usr/local/pxf /usr/local/pxf
 COPY --from=go_builder /tmp/gpbackman/gpbackman /usr/local/greenplum-db/bin/gpbackman
+COPY --from=go_builder /tmp/yproxy/devbin/yproxy /usr/local/greenplum-db/bin/yproxy
+COPY --from=go_builder /tmp/yproxy/devbin/yp-client /usr/local/greenplum-db/bin/yp-client
 COPY --from=go_builder /tmp/wal-g/main/gp/wal-g /usr/local/greenplum-db/bin/wal-g
 COPY --chmod=755 docker/files/entrypoint.sh /entrypoint.sh
-COPY --chmod=755 docker/files/start_gpdb.sh /start_gpdb.sh
+COPY --chmod=755 docker/files/opengpdb/start_gpdb.sh /start_gpdb.sh
 
 LABEL \
     org.opencontainers.image.version="${REPO_BUILD_TAG}" \

--- a/docker/opengpdb/ubuntu22.04/6/Dockerfile
+++ b/docker/opengpdb/ubuntu22.04/6/Dockerfile
@@ -5,8 +5,8 @@ ARG GPXERCES_DOWNLOAD_URL="https://github.com/woblerr/gp-xerces/archive/refs/tag
 ARG GPXERCES_VERSION="v3.1.2-p1"
 ARG LIBSIGAR_DOWNLOAD_URL="https://github.com/boundary/sigar"
 ARG LIBSIGAR_COMMIT_HASH="e8961a6674cc4d292e61b353b5c36bfc345434cc"
-ARG GPDB_DOWNLOAD_URL="https://github.com/woblerr/gpdb/archive/refs/tags"
-ARG GPDB_VERSION="6.27.1"
+ARG GPDB_DOWNLOAD_URL="https://github.com/open-gpdb/gpdb/archive/refs/tags"
+ARG GPDB_VERSION="6.29.3"
 ARG DISKQUOTA_DOWNLOAD_URL="https://github.com/woblerr/diskquota/archive/refs/tags"
 ARG DISKQUOTA_VERSION="2.3.0"
 ARG PXF_DOWNLOAD_URL="https://github.com/woblerr/pxf/archive/refs/tags"
@@ -136,6 +136,11 @@ RUN wget ${GPDB_DOWNLOAD_URL}/${GPDB_VERSION}.tar.gz -O /tmp/gpdb-${GPDB_VERSION
         --with-gssapi \
         --with-pythonsrc-ext \
         --with-uuid=e2fs \
+        # See https://github.com/open-gpdb/gpdb/commit/654c51834f820c716f41999751a7cb242bd66775
+        # and https://yandex.cloud/en/docs/managed-postgresql/tutorials/glibc-collation-issues
+        --without-mdblocales \
+        # Enable later
+        --disable-yezzey \
     && make -j2 \
     && make install \
     && rm -rf \
@@ -143,9 +148,15 @@ RUN wget ${GPDB_DOWNLOAD_URL}/${GPDB_VERSION}.tar.gz -O /tmp/gpdb-${GPDB_VERSION
         /tmp/gpdb-${GPDB_VERSION}.tar.gz
 
 # diskquota
+# Patched for compatibility with Open GPDB 6.29.3
+# The GetUserNameFromId function signature changed in commit:
+# https://github.com/open-gpdb/gpdb/commit/5cbe6b50acb061a7f1b661f8e344d5bcd3518b4d
+# Added 'bool noerr' parameter for new regrole type support
 RUN wget ${DISKQUOTA_DOWNLOAD_URL}/${DISKQUOTA_VERSION}.tar.gz -O /tmp/diskquota-${DISKQUOTA_VERSION}.tar.gz \
     && mkdir -p /tmp/diskquota \
     && tar -xzf /tmp/diskquota-${DISKQUOTA_VERSION}.tar.gz --strip-components=1 -C /tmp/diskquota \
+    # Patch quotamodel.c for Open GPDB 6.29.3
+    && sed -i 's/GetUserNameFromId(relowner)/GetUserNameFromId(relowner, false)/g' /tmp/diskquota/src/quotamodel.c \
     && mkdir -p /tmp/diskquota/build \
     && cd /tmp/diskquota/build \
     && cmake /tmp/diskquota \

--- a/docker/opengpdb/ubuntu22.04/6/Dockerfile
+++ b/docker/opengpdb/ubuntu22.04/6/Dockerfile
@@ -137,7 +137,7 @@ RUN wget ${GPDB_DOWNLOAD_URL}/${GPDB_VERSION}.tar.gz -O /tmp/gpdb-${GPDB_VERSION
     && cd /tmp/gpdb \
     && echo "${GPDB_VERSION} build dev" > /tmp/gpdb/VERSION \
     # Clone yezzey into gpcontrib before building GPDB
-    && git clone ${YEZZEY_DOWNLOAD_URL} gpcontrib/yezzey --depth 1 \
+    && git clone ${YEZZEY_DOWNLOAD_URL} gpcontrib/yezzey \
     && cd gpcontrib/yezzey \
     && git checkout ${YEZZEY_VERSION} \
     && cd /tmp/gpdb \

--- a/docs/yezzey_yproxy.md
+++ b/docs/yezzey_yproxy.md
@@ -1,0 +1,165 @@
+# Yezzey and Yproxy
+
+This document describes how to use Yezzey and Yproxy in the open-gpdb image. This functionality is available **only** for open-gpdb image.
+
+## Overview
+
+[Yezzey](https://github.com/open-gpdb/yezzey) is a Greenplum extension that allows offloading data from Append-Optimized (AO) and Append-Optimized Column-Oriented (AOCS) tables to S3-compatible storage. This enables:
+
+- Reducing load on local storage.
+- Working with data stored in S3 transparently for applications.
+- Saving costs on storing infrequently accessed data.
+
+[Yproxy](https://github.com/open-gpdb/yproxy) is a proxy service that provides communication between Yezzey and S3-compatible storage via Unix socket.
+
+## Requirements
+
+- `opengpdb` image (e.g., `opengpdb:6.29.3`).
+- S3-compatible storage.
+- `yproxy.yaml` configuration file.
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Description | Default Value |
+|----------|-------------|---------------|
+| `GREENPLUM_YEZZEY_ENABLE` | Enable Yezzey and Yproxy | `false` |
+
+When `GREENPLUM_YEZZEY_ENABLE=true`:
+- Yezzey extension is automatically added to `shared_preload_libraries`.
+- Yezzey extension is created in the database specified in `GREENPLUM_DATABASE_NAME`.
+- Yproxy service starts automatically.
+
+### yproxy.yaml Configuration File
+
+The `yproxy.yaml` configuration file must be mounted into the container at `/data/yproxy.yaml`.
+
+Example configuration:
+
+```yaml
+socket_path: "/tmp/yproxy.sock"
+storage:
+  storage_endpoint: "http://minio:9000"
+  storage_bucket: "yezzey"
+  storage_prefix: ""
+  storage_region: "us-west-1"
+  access_key_id: "demo"
+  secret_access_key: "demoBackup"
+
+logging:
+  level: "info"
+  format: "json"
+  output: "/data/yproxy.log"
+```
+
+## Running
+
+### Singlenode
+
+```bash
+docker run -p 5432:5432 \
+  -e GREENPLUM_PASSWORD=gparray \
+  -e GREENPLUM_YEZZEY_ENABLE=true \
+  -v $(pwd)/yproxy.yaml:/data/yproxy.yaml \
+  -d opengpdb:6.29.3
+```
+
+### Multi-node Cluster
+
+When deploying a cluster with master and segment hosts, you need to:
+
+1. Set `GREENPLUM_YEZZEY_ENABLE=true` on all cluster nodes.
+2. Mount `yproxy.yaml` to all cluster nodes at `/data/yproxy.yaml`.
+
+Example for master:
+
+```yaml
+services:
+  master:
+    image: opengpdb:6.29.3
+    environment:
+      - GREENPLUM_DEPLOYMENT=master
+      - GREENPLUM_YEZZEY_ENABLE=true
+      - GREENPLUM_PASSWORD_FILE=/run/secrets/gpdb_password
+    volumes:
+      - ./yproxy.yaml:/data/yproxy.yaml
+```
+
+Example for segment:
+
+```yaml
+services:
+  segment1:
+    image: opengpdb:6.29.3
+    command: /start_gpdb.sh "00:primary" "01:primary"
+    environment:
+      - GREENPLUM_DEPLOYMENT=segment
+      - GREENPLUM_YEZZEY_ENABLE=true
+    volumes:
+      - ./yproxy.yaml:/data/yproxy.yaml
+```
+
+Full docker-compose configuration example with Yezzey: [e2e-tests/docker-compose.yezzey.yml](../e2e-tests/docker-compose.yezzey.yml).
+
+## Logs and Debugging
+
+### Yproxy Logs
+
+Yproxy logs are written to the file specified in configuration (default `/data/yproxy.log`):
+
+```bash
+docker exec master cat /data/yproxy.log
+```
+
+### Checking Yproxy Status
+
+Verify that Yproxy is running:
+
+```bash
+docker exec master ls -la /tmp/yproxy.sock
+```
+
+### yp-client Utility
+
+The image includes `yp-client` utility for debugging Yproxy interactions:
+
+```bash
+docker exec master yp-client --help
+```
+
+## E2E Tests
+
+Full Yezzey usage example is provided in e2e tests:
+
+- Docker Compose configuration: [e2e-tests/docker-compose.yezzey.yml](../e2e-tests/docker-compose.yezzey.yml)
+- Test script: [e2e-tests/scripts/e2e-yezzey-test.sh](../e2e-tests/scripts/e2e-yezzey-test.sh)
+- Yproxy configuration: [e2e-tests/yezzey/yproxy.yaml](../e2e-tests/yezzey/yproxy.yaml)
+- SQL initialization script: [e2e-tests/yezzey/init_scripts/yezzey_init.sql](../e2e-tests/yezzey/init_scripts/yezzey_init.sql)
+
+### Running Tests
+
+```bash
+make test-e2e-yezzey
+```
+
+Or manually:
+
+```bash
+cd e2e-tests
+docker compose -f docker-compose.s3.yml -f docker-compose.yezzey.yml up -d
+GREENPLUM_PASSWORD=$(cat ../docker-compose/secrets/gpdb_password) ./scripts/e2e-yezzey-test.sh
+docker compose -f -f docker-compose.s3.yml -f docker-compose.yezzey.yml down
+```
+
+### What Tests Verify
+
+1. **AO tables:**
+   - Data offload to S3.
+   - Data accessibility after offload.
+   - DELETE and VACUUM on offloaded table.
+   - Loading data back to local storage.
+   - Re-offload and VACUUM (YEZZEY).
+
+2. **AOCS tables:**
+   - Same set of operations for column-oriented tables.

--- a/docs/yezzey_yproxy.md
+++ b/docs/yezzey_yproxy.md
@@ -149,7 +149,7 @@ Or manually:
 cd e2e-tests
 docker compose -f docker-compose.s3.yml -f docker-compose.yezzey.yml up -d
 GREENPLUM_PASSWORD=$(cat ../docker-compose/secrets/gpdb_password) ./scripts/e2e-yezzey-test.sh
-docker compose -f -f docker-compose.s3.yml -f docker-compose.yezzey.yml down
+docker compose -f docker-compose.s3.yml -f docker-compose.yezzey.yml down
 ```
 
 ### What Tests Verify

--- a/e2e-tests/.env
+++ b/e2e-tests/.env
@@ -60,6 +60,20 @@ RESTORE_CONFIG_FOLDER="6"
 #RESTORE_TAG=7.3.0-WHPG-oraclelinux8
 #RESTORE_CONFIG_FOLDER="7"
 
+
+# OpenGPDB
+# -------------------------------------
+#IMAGE_NAME="opengpdb"
+# For OpenGPDB 6 on Ubuntu 22.04
+#TAG=6.29.3-ubuntu22.04
+#CONFIG_FOLDER="6"
+
+# OpenGPDB RESTORE
+# -------------------------------------
+# For GPDB 6 on Ubuntu 22.04
+#RESTORE_TAG=6.29.3-ubuntu22.04
+#RESTORE_CONFIG_FOLDER="6"
+
 EXPOSE_MASTER_PORT=5432
 # RESTORE EXPOSE PORTS
 EXPOSE_RESTORE_MASTER_PORT=6432

--- a/e2e-tests/Makefile
+++ b/e2e-tests/Makefile
@@ -26,3 +26,26 @@ test-e2e-walg-down:
 	@echo "INFO - Stop e2e tests for wal-g"
 	docker compose -f docker-compose.s3.yml -f docker-compose.gpdb.yml -f docker-compose.gpdb-restore.yml down
 
+.PHONY: test-e2e-yezzey
+test-e2e-yezzey:
+	make test-e2e-yezzey-down
+	make test-e2e-yezzey-up
+	make test-e2e-yezzey-run
+	make test-e2e-yezzey-down
+
+.PHONY: test-e2e-yezzey-up
+test-e2e-yezzey-up:
+	@echo "INFO - Start e2e tests for Yezzey"
+	docker compose -f docker-compose.s3.yml -f docker-compose.yezzey.yml up -d
+
+.PHONY: test-e2e-yezzey-run
+test-e2e-yezzey-run:
+	@echo "INFO - Run e2e tests for Yezzey"
+	GREENPLUM_PASSWORD=$(GPDB_PASSWORD) ./scripts/e2e-yezzey-test.sh
+
+.PHONY: test-e2e-yezzey-down
+test-e2e-yezzey-down:
+	@echo "INFO - Stop e2e tests for Yezzey"
+	docker compose -f docker-compose.s3.yml -f docker-compose.yezzey.yml down
+
+

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -2,7 +2,7 @@
 
 The following architecture is used to run the tests:
 
-* Separate containers with Greenplum (GPDB, Greengage, or WarehousePG).
+* Separate containers with Greenplum (GPDB, Greengage, WarehousePG, or open-gpdb).
 * Separate containers for MinIO and nginx. Official images [minio/minio](https://hub.docker.com/r/minio/minio), [minio/mc](https://hub.docker.com/r/minio/mc) and [nginx](https://hub.docker.com/_/nginx) are used. It's necessary for S3 compatible storage for WAL archiving and backups.
 
 ## Prerequisites
@@ -11,7 +11,7 @@ Before running tests:
 
 1. Build Greenplum docker images as described in [Build section](../README.md#build).
 
-2. Configure test environment by editing `e2e-tests/.env` file if needed (default: `GPDB 6.27.1`, other supported: `Greengage`, `WarehousePG`).
+2. Configure test environment by editing `e2e-tests/.env` file if needed (default: `GPDB 6.27.1`, other supported: `Greengage`, `WarehousePG`, `open-gpdb`).
 
 3. Prepare password files as described in [Prepare section](../README.md#prepare) for Docker Compose. In tests used ssh keys from `e2e-tests/conf/ssh/` directory, so you can use them or create your own.
 
@@ -61,4 +61,49 @@ cd [docker-greenplum-root]/e2e-tests
 docker compose -f docker-compose.s3.yml -f docker-compose.gpdb.yml -f docker-compose.gpdb-restore.yml up -d
 GREENPLUM_PASSWORD=$(cat ../docker-compose/secrets/gpdb_password) ./scripts/e2e-test.sh
 docker compose -f docker-compose.s3.yml -f docker-compose.gpdb.yml -f docker-compose.gpdb-restore.yml down
+```
+
+### Yezzey tests
+
+Cluster is described in `e2e-tests/docker-compose.yezzey.yml`, and S3 compatible storage is reused from `e2e-tests/docker-compose.s3.yml`.
+
+The test validates Yezzey data offloading functionality for OpenGPDB. Test tables are created during cluster initialization via [yezzey_init.sql](./yezzey/init_scripts/yezzey_init.sql).
+
+1. **AO table test** (`yezzey_test_ao`):
+   - Offloads table data to S3 using `yezzey_define_offload_policy()`
+   - Verifies data is still accessible after offload
+   - Performs DELETE and VACUUM operations on offloaded table
+   - Loads data back to local storage using `yezzey_load_relation()`
+   - Re-offloads and runs VACUUM (YEZZEY) for S3 cleanup
+
+2. **AOCS table test** (`yezzey_test_aocs`):
+   - Same set of operations for column-oriented table
+
+**Note:** Yezzey tests are only supported for open-gpdb image.
+
+For more details about Yezzey and Yproxy, see [Yezzey and Yproxy documentation](../docs/yezzey_yproxy.md).
+
+Run:
+
+```bash
+make test-e2e-yezzey
+```
+
+or
+
+```bash
+cd e2e-tests
+make test-e2e-yezzey
+```
+
+or manually:
+
+```bash
+cd [docker-greenplum-root]/e2e-tests
+```bash
+cd e2e-tests
+docker compose -f docker-compose.s3.yml -f docker-compose.yezzey.yml up -d
+GREENPLUM_PASSWORD=$(cat ../docker-compose/secrets/gpdb_password) ./scripts/e2e-yezzey-test.sh
+docker compose -f -f docker-compose.s3.yml -f docker-compose.yezzey.yml down
+```
 ```

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -104,6 +104,5 @@ cd [docker-greenplum-root]/e2e-tests
 cd e2e-tests
 docker compose -f docker-compose.s3.yml -f docker-compose.yezzey.yml up -d
 GREENPLUM_PASSWORD=$(cat ../docker-compose/secrets/gpdb_password) ./scripts/e2e-yezzey-test.sh
-docker compose -f -f docker-compose.s3.yml -f docker-compose.yezzey.yml down
-```
+docker compose -f docker-compose.s3.yml -f docker-compose.yezzey.yml down
 ```

--- a/e2e-tests/docker-compose.yezzey.yml
+++ b/e2e-tests/docker-compose.yezzey.yml
@@ -1,0 +1,94 @@
+version: '3'
+
+services:
+  createbucket-yezzey:
+    image: minio/mc:${IMAGE_TAG_MINIO_MC}
+    container_name: createbucket-yezzey
+    environment:
+      - "MINIO_ROOT_USER"
+      - "MINIO_ROOT_PASSWORD"
+      - "S3_MINIO_KEY"
+      - "S3_MINIO_KEY_SECRET"
+      - "S3_MINIO_HOSTNAME"
+    depends_on:
+      minio:
+        condition: service_healthy
+      nginx:
+        condition: service_started
+    entrypoint: >
+      /bin/sh -c '
+      mc alias set \
+        "${S3_MINIO_HOSTNAME}" \
+        http://minio:9000 \
+        "${MINIO_ROOT_USER}" \
+        "${MINIO_ROOT_PASSWORD}";
+      mc mb "${S3_MINIO_HOSTNAME}"/yezzey;
+      mc admin user add "${S3_MINIO_HOSTNAME}" "${S3_MINIO_KEY}" "${S3_MINIO_KEY_SECRET}";
+      mc admin policy attach "${S3_MINIO_HOSTNAME}" readwrite --user="${S3_MINIO_KEY}";
+      exit 0;
+      '
+    networks:
+      - greenplum
+
+  master:
+    image: ${IMAGE_NAME}:${TAG}
+    container_name: master
+    hostname: master
+    ports:
+      - "${EXPOSE_MASTER_PORT}:5432"
+    environment:
+      - GREENPLUM_DEPLOYMENT=master
+      - GREENPLUM_YEZZEY_ENABLE=true
+      - GREENPLUM_PASSWORD_FILE=/run/secrets/gpdb_password
+    secrets:
+      - gpdb_password
+    volumes:
+      - ../docker-compose/conf/${CONFIG_FOLDER}/gpinitsystem_config_no_mirrors:/tmp/gpinitsystem_config
+      - ../docker-compose/conf/hostfile_gpinitsystem:/tmp/hostfile_gpinitsystem
+      - ../docker-compose/conf/ssh/id_rsa:/home/gpadmin/.ssh/id_rsa
+      - ../docker-compose/conf/ssh/id_rsa.pub:/home/gpadmin/.ssh/id_rsa.pub
+      - ./yezzey/yproxy.yaml:/data/yproxy.yaml
+      - ./yezzey/init_scripts/yezzey_init.sql:/docker-entrypoint-initdb.d/yezzey_init.sql
+    depends_on:
+      - segment1
+      - segment2
+      - createbucket-yezzey
+    networks:
+      - greenplum
+
+  segment1:
+    image: ${IMAGE_NAME}:${TAG}
+    container_name: segment1
+    hostname: segment1
+    command: /start_gpdb.sh "00:primary" "01:primary"
+    environment:
+      - GREENPLUM_DEPLOYMENT=segment
+      - GREENPLUM_YEZZEY_ENABLE=true
+    volumes:
+      - ../docker-compose/conf/ssh/authorized_keys:/tmp/authorized_keys
+      - ./yezzey/yproxy.yaml:/data/yproxy.yaml
+    stop_grace_period: 60s
+    networks:
+      - greenplum
+
+  segment2:
+    image: ${IMAGE_NAME}:${TAG}
+    container_name: segment2
+    hostname: segment2
+    command: /start_gpdb.sh "00:primary" "01:primary"
+    environment:
+      - GREENPLUM_DEPLOYMENT=segment
+      - GREENPLUM_YEZZEY_ENABLE=true
+    volumes:
+      - ../docker-compose/conf/ssh/authorized_keys:/tmp/authorized_keys
+      - ./yezzey/yproxy.yaml:/data/yproxy.yaml
+    stop_grace_period: 60s
+    networks:
+      - greenplum
+
+networks:
+  greenplum:
+
+secrets:
+  gpdb_password:
+    file: ../docker-compose/secrets/gpdb_password

--- a/e2e-tests/scripts/e2e-yezzey-test.sh
+++ b/e2e-tests/scripts/e2e-yezzey-test.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+GP_USER=${GREENPLUM_USER:-gpadmin}
+GP_PASSWORD=${GREENPLUM_PASSWORD:-}
+GP_MASTER_PORT=${EXPOSE_MASTER_PORT:-5432}
+GP_DB_NAME=${GREENPLUM_DB_NAME:-demo}
+
+MASTER_CONTAINER="master"
+YPROXY_SOCKET="/tmp/yproxy.sock"
+YPROXY_LOG="/data/yproxy.log"
+
+# Check password is set
+if [ -z "$GP_PASSWORD" ]; then
+    echo "ERROR - GP_PASSWORD variable is not set"
+    exit 1
+fi
+
+exec_sql() {
+    local port=$1
+    local sql=$2
+    PGPASSWORD=${GP_PASSWORD} psql -h localhost -U ${GP_USER} -d ${GP_DB_NAME} -p ${port} -t -c "${sql}"
+}
+
+exec_docker() {
+    local container_name=$1
+    local cmd=$2
+    docker exec ${container_name} su - ${GP_USER} -c "${cmd}"
+}
+
+wait_for_service() {
+    local port=$1
+    local max_attempts=${2:-10}
+
+    for i in $(seq 1 ${max_attempts}); do
+        if exec_sql ${port} "SELECT 1;" >/dev/null 2>&1; then
+            echo "INFO - Cluster ready"
+            return 0
+        fi
+        echo "INFO - Waiting cluster startup ($i/${max_attempts})"
+        sleep 10
+    done
+    echo "ERROR - Cluster failed to start within timeout"
+    return 1
+}
+
+compare_data() {
+    local primary_data=$1
+    local standby_data=$2
+
+    echo "INFO - Row count first argument:"
+    echo "$primary_data"
+    echo "INFO - Row count second argument:"
+    echo "$standby_data"
+
+    if [ "$primary_data" = "$standby_data" ]; then
+        echo "INFO - Data matches"
+    else
+        echo "ERROR - Data mismatch"
+        exit 1
+    fi
+}
+
+echo "INFO - Check Greenplum cluster"
+sleep 90
+echo "INFO - Waiting cluster startup"
+wait_for_service ${GP_MASTER_PORT}
+
+# Test AO table
+echo "INFO - Test AO (Append-Optimized) table"
+echo "INFO - Check row count before offload"
+row_count_before=$(exec_sql ${GP_MASTER_PORT} "SELECT COUNT(*) FROM yezzey_test_ao;")
+echo "INFO - Row count before offload: $row_count_before"
+
+echo "INFO - Offload AO table to S3"
+exec_sql ${GP_MASTER_PORT} "SELECT yezzey_define_offload_policy('yezzey_test_ao');"
+echo "INFO - Check row count after offload"
+row_count_after=$(exec_sql ${GP_MASTER_PORT} "SELECT COUNT(*) FROM yezzey_test_ao;")
+echo "INFO - Row count after offload: $row_count_after (data accessible from S3)"
+
+compare_data "$row_count_before" "$row_count_after"
+
+echo "INFO - Test DELETE after offload"
+exec_sql ${GP_MASTER_PORT} "DELETE FROM yezzey_test_ao where id <= 5000;"
+row_count_after_delete=$(exec_sql ${GP_MASTER_PORT} "SELECT COUNT(*) FROM yezzey_test_ao;")
+echo "INFO - Row count after DELETE: $row_count_after_delete"
+
+echo "INFO - Run VACUUM on AO table"
+exec_sql ${GP_MASTER_PORT} "VACUUM yezzey_test_ao;"
+row_count_after_vacuum=$(exec_sql ${GP_MASTER_PORT} "SELECT COUNT(*) FROM yezzey_test_ao;")
+echo "INFO - Row count after VACUUM: $row_count_after_vacuum (no dead tuples)"
+
+compare_data "$row_count_after_delete" "$row_count_after_vacuum"
+
+echo "INFO - Load AO table back to local storage"
+exec_sql ${GP_MASTER_PORT} "SELECT yezzey_load_relation('yezzey_test_ao');"
+row_count_after_load=$(exec_sql ${GP_MASTER_PORT} "SELECT COUNT(*) FROM yezzey_test_ao;")
+echo "INFO - Row count after load from S3: $row_count_after_load"
+
+echo "INFO - Offload AO table to S3 again"
+exec_sql ${GP_MASTER_PORT} "SELECT yezzey_define_offload_policy('yezzey_test_ao');"
+echo "INFO - Run VACUUM (YEZZEY) on AO table"
+exec_sql ${GP_MASTER_PORT} "VACUUM (YEZZEY) yezzey_test_ao;"
+row_count_final=$(exec_sql ${GP_MASTER_PORT} "SELECT COUNT(*) FROM yezzey_test_ao;" )
+echo "INFO - Final AO row count: $row_count_final"
+
+compare_data "$row_count_after_load" "$row_count_final"
+
+# Test AOCO table
+echo "INFO - Test AOCO (Column-Oriented) table"
+echo "INFO - Create AOCO table"
+echo "INFO - Check row count before offload"
+row_count_aocs_before=$(exec_sql ${GP_MASTER_PORT} "SELECT COUNT(*) FROM yezzey_test_aocs;")
+echo "INFO - Row count before offload: $row_count_aocs_before"
+
+echo "INFO - Offload AOCO table to S3"
+exec_sql ${GP_MASTER_PORT} "SELECT yezzey_define_offload_policy('yezzey_test_aocs');"
+echo "INFO - Check row count after offload"
+row_count_aocs_after=$(exec_sql ${GP_MASTER_PORT} "SELECT COUNT(*) FROM yezzey_test_aocs;")
+echo "INFO - Row count after offload: $row_count_aocs_after (data accessible from S3)"
+
+compare_data "$row_count_aocs_before" "$row_count_aocs_after"
+
+echo "INFO - Test DELETE after offload"
+exec_sql ${GP_MASTER_PORT} "DELETE FROM yezzey_test_aocs WHERE id <= 5000;"
+row_count_aocs_after_delete=$(exec_sql ${GP_MASTER_PORT} "SELECT COUNT(*) FROM yezzey_test_aocs;")
+echo "INFO - Row count after DELETE: $row_count_aocs_after_delete"
+
+echo "INFO - Run VACUUM on AOCO table"
+exec_sql ${GP_MASTER_PORT} "VACUUM yezzey_test_aocs;"
+row_count_aocs_after_vacuum=$(exec_sql ${GP_MASTER_PORT} "SELECT COUNT(*) FROM yezzey_test_aocs;")
+echo "INFO - Row count after VACUUM: $row_count_aocs_after_vacuum (no dead tuples)"
+
+compare_data "$row_count_aocs_after_delete" "$row_count_aocs_after_vacuum"
+
+echo "INFO - Load AOCO table back to local storage"
+exec_sql ${GP_MASTER_PORT} "SELECT yezzey_load_relation('yezzey_test_aocs');"
+row_count_aocs_after_load=$(exec_sql ${GP_MASTER_PORT} "SELECT COUNT(*) FROM yezzey_test_aocs;")
+echo "INFO - Row count after load from S3: $row_count_aocs_after_load"
+
+echo "INFO - Offload AOCO table to S3 again"
+exec_sql ${GP_MASTER_PORT} "SELECT yezzey_define_offload_policy('yezzey_test_aocs');"
+echo "INFO - Run VACUUM (YEZZEY) on AOCO table"
+exec_sql ${GP_MASTER_PORT} "VACUUM (YEZZEY) yezzey_test_aocs;"
+row_count_aocs_final=$(exec_sql ${GP_MASTER_PORT} "SELECT COUNT(*) FROM yezzey_test_aocs;")
+echo "INFO - Final AOCO row count: $row_count_aocs_final"
+
+compare_data "$row_count_aocs_after_load" "$row_count_aocs_final"
+
+echo "INFO - Yezzey E2E tests completed successfully"

--- a/e2e-tests/yezzey/init_scripts/yezzey_init.sql
+++ b/e2e-tests/yezzey/init_scripts/yezzey_init.sql
@@ -1,0 +1,24 @@
+-- AO table test
+CREATE TABLE yezzey_test_ao (
+    id INT,
+    data TEXT
+) WITH (appendonly=true);
+
+-- Insert test data
+INSERT INTO yezzey_test_ao (id, data) 
+SELECT i, md5(random()::text) 
+FROM generate_series(1, 10000) i;
+
+
+-- AOCS table test
+CREATE TABLE yezzey_test_aocs (
+    id INT,
+    col1 INT,
+    col2 INT,
+    data TEXT
+) WITH (appendonly=true, orientation=column);
+
+-- Insert test data
+INSERT INTO yezzey_test_aocs (id, col1, col2, data) 
+SELECT i, i, i, md5(random()::text) 
+FROM generate_series(1, 10000) i;

--- a/e2e-tests/yezzey/yproxy.yaml
+++ b/e2e-tests/yezzey/yproxy.yaml
@@ -1,0 +1,13 @@
+socket_path: "/tmp/yproxy.sock"
+storage:
+  storage_endpoint: "http://minio:9000"
+  storage_bucket: "yezzey"
+  storage_prefix: ""
+  storage_region: "us-west-1"
+  access_key_id: "demo"
+  secret_access_key: "demoBackup"
+
+logging:
+  level: "info"
+  format: "json"
+  output: "/data/yproxy.log"


### PR DESCRIPTION
open-gpdb (https://github.com/open-gpdb/gpdb) is an open source fork of Greenplum Database.

Changes:
* Add Dockerfiles for open-gpdb 6 (Ubuntu 22.04)
* Add CI workflow for building and publishing open-gpdb 6  images
* Add Makefile targets: build_opengpdb_6_ubuntu
* Update docker-compose .env files with open-gpdb configuration
* Update documentation with open-gpdb build matrix and pull instructions
* Add documentation with examples for Yezzey and Yproxy

Since additional steps are required for Yezzey and Yproxy, a separate script `start_gpdb.sh` has been created for open-gpdb .