### PR TITLE
Add selective CI triggering based on changed files.

### DIFF
--- a/.github/workflows/build-gpdb6.yml
+++ b/.github/workflows/build-gpdb6.yml
@@ -3,7 +3,36 @@ name: build-gpdb6
 on: [push, pull_request]
 
 jobs:
+  detect_changes:
+    runs-on: ubuntu-22.04
+    outputs:
+      project_changed: ${{ steps.changed-files.outputs.project_any_changed }}
+      common_changed: ${{ steps.changed-files.outputs.common_any_changed }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed files
+        id: changed-files
+        uses: tj-actions/changed-files@7dee1b0c1557f278e5c7dc244927139d78c0e22a
+        with:
+          files_yaml: |
+            project:
+              - 'docker/greenplum/**/6/**'
+            common:
+              - 'docker/files/entrypoint.sh'
+              - 'docker/files/start_gpdb.sh'
+              - '.github/workflows/build-gpdb6.yml'
+
   build_image:
+    needs: [detect_changes]
+    if: |
+      needs.detect_changes.outputs.project_changed == 'true' ||
+      needs.detect_changes.outputs.common_changed == 'true' ||
+      github.ref == 'refs/heads/master' ||
+      startsWith(github.ref, 'refs/tags/')
     runs-on: ${{ matrix.platform == 'linux/arm64' && 'ubuntu-22.04-arm' || 'ubuntu-22.04' }}
     strategy:
       matrix:

--- a/.github/workflows/build-gpdb6.yml
+++ b/.github/workflows/build-gpdb6.yml
@@ -16,6 +16,7 @@ jobs:
 
       - name: Detect changed files
         id: changed-files
+        # tj-actions/changed-files@v47.0.4
         uses: tj-actions/changed-files@7dee1b0c1557f278e5c7dc244927139d78c0e22a
         with:
           files_yaml: |
@@ -25,6 +26,17 @@ jobs:
               - 'docker/files/entrypoint.sh'
               - 'docker/files/start_gpdb.sh'
               - '.github/workflows/build-gpdb6.yml'
+
+      - name: Log build trigger reason
+        run: |
+          if [[ "${{ steps.changed-files.outputs.project_any_changed }}" == "true" || \
+               "${{ steps.changed-files.outputs.common_any_changed }}" == "true" || \
+               "${{ github.ref }}" == "refs/heads/master" || \
+               "${{ github.ref }}" == refs/tags/* ]]; then
+            echo "build_image will run"
+          else
+            echo "build_image will be skipped"
+          fi
 
   build_image:
     needs: [detect_changes]

--- a/.github/workflows/build-gpdb7.yml
+++ b/.github/workflows/build-gpdb7.yml
@@ -3,7 +3,48 @@ name: build-gpdb7
 on: [push, pull_request]
 
 jobs:
+  detect_changes:
+    runs-on: ubuntu-22.04
+    outputs:
+      project_changed: ${{ steps.changed-files.outputs.project_any_changed }}
+      common_changed: ${{ steps.changed-files.outputs.common_any_changed }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed files
+        id: changed-files
+        # tj-actions/changed-files@v47.0.4
+        uses: tj-actions/changed-files@7dee1b0c1557f278e5c7dc244927139d78c0e22a
+        with:
+          files_yaml: |
+            project:
+              - 'docker/greenplum/**/7/**'
+            common:
+              - 'docker/files/entrypoint.sh'
+              - 'docker/files/start_gpdb.sh'
+              - '.github/workflows/build-gpdb7.yml'
+
+      - name: Log build trigger reason
+        run: |
+          if [[ "${{ steps.changed-files.outputs.project_any_changed }}" == "true" || \
+               "${{ steps.changed-files.outputs.common_any_changed }}" == "true" || \
+               "${{ github.ref }}" == "refs/heads/master" || \
+               "${{ github.ref }}" == refs/tags/* ]]; then
+            echo "build_image will run"
+          else
+            echo "build_image will be skipped"
+          fi
+
   build_image:
+    needs: [detect_changes]
+    if: |
+      needs.detect_changes.outputs.project_changed == 'true' ||
+      needs.detect_changes.outputs.common_changed == 'true' ||
+      github.ref == 'refs/heads/master' ||
+      startsWith(github.ref, 'refs/tags/')
     # Use native ARM64 runners for arm64 platform, standard x64 runners for amd64
     runs-on: ${{ matrix.platform == 'linux/arm64' && 'ubuntu-22.04-arm' || 'ubuntu-22.04' }}
     strategy:

--- a/.github/workflows/build-greengage6.yml
+++ b/.github/workflows/build-greengage6.yml
@@ -3,7 +3,47 @@ name: build-greengage6
 on: [push, pull_request]
 
 jobs:
+  detect_changes:
+    runs-on: ubuntu-22.04
+    outputs:
+      project_changed: ${{ steps.changed-files.outputs.project_any_changed }}
+      common_changed: ${{ steps.changed-files.outputs.common_any_changed }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed files
+        id: changed-files
+        uses: tj-actions/changed-files@7dee1b0c1557f278e5c7dc244927139d78c0e22a
+        with:
+          files_yaml: |
+            project:
+              - 'docker/greengage/**/6/**'
+            common:
+              - 'docker/files/entrypoint.sh'
+              - 'docker/files/start_gpdb.sh'
+              - '.github/workflows/build-greengage6.yml'
+
+      - name: Log build trigger reason
+        run: |
+          if [[ "${{ steps.changed-files.outputs.project_any_changed }}" == "true" || \
+               "${{ steps.changed-files.outputs.common_any_changed }}" == "true" || \
+               "${{ github.ref }}" == "refs/heads/master" || \
+               "${{ github.ref }}" == refs/tags/* ]]; then
+            echo "build_image will run"
+          else
+            echo "build_image will be skipped"
+          fi
+
   build_image:
+    needs: [detect_changes]
+    if: |
+      needs.detect_changes.outputs.project_changed == 'true' ||
+      needs.detect_changes.outputs.common_changed == 'true' ||
+      github.ref == 'refs/heads/master' ||
+      startsWith(github.ref, 'refs/tags/')
     runs-on: ${{ matrix.platform == 'linux/arm64' && 'ubuntu-22.04-arm' || 'ubuntu-22.04' }}
     strategy:
       matrix:

--- a/.github/workflows/build-greengage7.yml
+++ b/.github/workflows/build-greengage7.yml
@@ -3,7 +3,47 @@ name: build-greengage7
 on: [push, pull_request]
 
 jobs:
+  detect_changes:
+    runs-on: ubuntu-22.04
+    outputs:
+      project_changed: ${{ steps.changed-files.outputs.project_any_changed }}
+      common_changed: ${{ steps.changed-files.outputs.common_any_changed }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed files
+        id: changed-files
+        uses: tj-actions/changed-files@7dee1b0c1557f278e5c7dc244927139d78c0e22a
+        with:
+          files_yaml: |
+            project:
+              - 'docker/greengage/**/7/**'
+            common:
+              - 'docker/files/entrypoint.sh'
+              - 'docker/files/start_gpdb.sh'
+              - '.github/workflows/build-greengage7.yml'
+
+      - name: Log build trigger reason
+        run: |
+          if [[ "${{ steps.changed-files.outputs.project_any_changed }}" == "true" || \
+               "${{ steps.changed-files.outputs.common_any_changed }}" == "true" || \
+               "${{ github.ref }}" == "refs/heads/master" || \
+               "${{ github.ref }}" == refs/tags/* ]]; then
+            echo "build_image will run"
+          else
+            echo "build_image will be skipped"
+          fi
+
   build_image:
+    needs: [detect_changes]
+    if: |
+      needs.detect_changes.outputs.project_changed == 'true' ||
+      needs.detect_changes.outputs.common_changed == 'true' ||
+      github.ref == 'refs/heads/master' ||
+      startsWith(github.ref, 'refs/tags/')
     runs-on: ${{ matrix.platform == 'linux/arm64' && 'ubuntu-22.04-arm' || 'ubuntu-22.04' }}
     strategy:
       matrix:

--- a/.github/workflows/build-opengpdb6.yml
+++ b/.github/workflows/build-opengpdb6.yml
@@ -3,7 +3,47 @@ name: build-opengpdb6
 on: [push, pull_request]
 
 jobs:
+  detect_changes:
+    runs-on: ubuntu-22.04
+    outputs:
+      project_changed: ${{ steps.changed-files.outputs.project_any_changed }}
+      common_changed: ${{ steps.changed-files.outputs.common_any_changed }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed files
+        id: changed-files
+        uses: tj-actions/changed-files@7dee1b0c1557f278e5c7dc244927139d78c0e22a
+        with:
+          files_yaml: |
+            project:
+              - 'docker/opengpdb/**/6/**'
+            common:
+              - 'docker/files/entrypoint.sh'
+              - 'docker/files/opengpdb/start_gpdb.sh'
+              - '.github/workflows/build-opengpdb6.yml'
+
+      - name: Log build trigger reason
+        run: |
+          if [[ "${{ steps.changed-files.outputs.project_any_changed }}" == "true" || \
+               "${{ steps.changed-files.outputs.common_any_changed }}" == "true" || \
+               "${{ github.ref }}" == "refs/heads/master" || \
+               "${{ github.ref }}" == refs/tags/* ]]; then
+            echo "build_image will run"
+          else
+            echo "build_image will be skipped"
+          fi
+
   build_image:
+    needs: [detect_changes]
+    if: |
+      needs.detect_changes.outputs.project_changed == 'true' ||
+      needs.detect_changes.outputs.common_changed == 'true' ||
+      github.ref == 'refs/heads/master' ||
+      startsWith(github.ref, 'refs/tags/')
     runs-on: ${{ matrix.platform == 'linux/arm64' && 'ubuntu-22.04-arm' || 'ubuntu-22.04' }}
     strategy:
       matrix:

--- a/.github/workflows/build-warehousepg6.yml
+++ b/.github/workflows/build-warehousepg6.yml
@@ -3,7 +3,47 @@ name: build-warehousepg6
 on: [push, pull_request]
 
 jobs:
+  detect_changes:
+    runs-on: ubuntu-22.04
+    outputs:
+      project_changed: ${{ steps.changed-files.outputs.project_any_changed }}
+      common_changed: ${{ steps.changed-files.outputs.common_any_changed }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed files
+        id: changed-files
+        uses: tj-actions/changed-files@7dee1b0c1557f278e5c7dc244927139d78c0e22a
+        with:
+          files_yaml: |
+            project:
+              - 'docker/warehousepg/**/6/**'
+            common:
+              - 'docker/files/entrypoint.sh'
+              - 'docker/files/start_gpdb.sh'
+              - '.github/workflows/build-warehousepg6.yml'
+
+      - name: Log build trigger reason
+        run: |
+          if [[ "${{ steps.changed-files.outputs.project_any_changed }}" == "true" || \
+               "${{ steps.changed-files.outputs.common_any_changed }}" == "true" || \
+               "${{ github.ref }}" == "refs/heads/master" || \
+               "${{ github.ref }}" == refs/tags/* ]]; then
+            echo "build_image will run"
+          else
+            echo "build_image will be skipped"
+          fi
+
   build_image:
+    needs: [detect_changes]
+    if: |
+      needs.detect_changes.outputs.project_changed == 'true' ||
+      needs.detect_changes.outputs.common_changed == 'true' ||
+      github.ref == 'refs/heads/master' ||
+      startsWith(github.ref, 'refs/tags/')
     runs-on: ${{ matrix.platform == 'linux/arm64' && 'ubuntu-22.04-arm' || 'ubuntu-22.04' }}
     strategy:
       matrix:

--- a/.github/workflows/build-warehousepg7.yml
+++ b/.github/workflows/build-warehousepg7.yml
@@ -3,7 +3,47 @@ name: build-warehousepg7
 on: [push, pull_request]
 
 jobs:
+  detect_changes:
+    runs-on: ubuntu-22.04
+    outputs:
+      project_changed: ${{ steps.changed-files.outputs.project_any_changed }}
+      common_changed: ${{ steps.changed-files.outputs.common_any_changed }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed files
+        id: changed-files
+        uses: tj-actions/changed-files@7dee1b0c1557f278e5c7dc244927139d78c0e22a
+        with:
+          files_yaml: |
+            project:
+              - 'docker/warehousepg/**/7/**'
+            common:
+              - 'docker/files/entrypoint.sh'
+              - 'docker/files/start_gpdb.sh'
+              - '.github/workflows/build-warehousepg7.yml'
+
+      - name: Log build trigger reason
+        run: |
+          if [[ "${{ steps.changed-files.outputs.project_any_changed }}" == "true" || \
+               "${{ steps.changed-files.outputs.common_any_changed }}" == "true" || \
+               "${{ github.ref }}" == "refs/heads/master" || \
+               "${{ github.ref }}" == refs/tags/* ]]; then
+            echo "build_image will run"
+          else
+            echo "build_image will be skipped"
+          fi
+
   build_image:
+    needs: [detect_changes]
+    if: |
+      needs.detect_changes.outputs.project_changed == 'true' ||
+      needs.detect_changes.outputs.common_changed == 'true' ||
+      github.ref == 'refs/heads/master' ||
+      startsWith(github.ref, 'refs/tags/')
     runs-on: ${{ matrix.platform == 'linux/arm64' && 'ubuntu-22.04-arm' || 'ubuntu-22.04' }}
     strategy:
       matrix:


### PR DESCRIPTION
Add `detect_changes` job to workflows to skip `build_image` when no relevant files are changed.

Uses `tj-actions/changed-files@v47.0.4` (pinned to SHA `7dee1b0c`) with `fetch-depth: 0` for full git history.

`build_image `runs only when:
* project-specific Dockerfiles are modified;
* common scripts are modified (`entrypoint.sh`, `start_gpdb.sh`);
* the workflow file itself is modified;
* push to `master` or a tag push;
