### PR TITLE
Bump go, gpbackman and wal-g versions.

### DIFF
--- a/docker/files/start_gpdb.sh
+++ b/docker/files/start_gpdb.sh
@@ -38,8 +38,12 @@ setup_version_config() {
     # Get gpdb major version from gpinitsystem command.
     # It's necessary to know the version to operate with the correct directories.
     # Example: gpinitsystem 6.26.4 build dev
-    gp_major_version=$(gpinitsystem --version | cut -d' ' -f2 | cut -d'.' -f1)
-    case ${gp_major_version} in
+    gp_version_string=$(gpinitsystem --version)
+    gp_major_version=""
+    if [[ "${gp_version_string}" =~ ([0-9]+)[.][0-9]+[.][0-9]+ ]]; then
+        gp_major_version="${BASH_REMATCH[1]}"
+    fi
+    case "${gp_major_version}" in
       "6")
         gp_log_dir="pg_log"
         gp_master_data_dir_prefix="MASTER"
@@ -49,7 +53,7 @@ setup_version_config() {
         gp_master_data_dir_prefix="COORDINATOR"
         ;;
       *)
-        error_and_exit "Invalid Greenplum version: ${gp_major_version}"
+        error_and_exit "Invalid Greenplum version from gpinitsystem output: ${gp_version_string}"
         ;;
     esac
 }

--- a/docker/greengage/oraclelinux8/6/Dockerfile
+++ b/docker/greengage/oraclelinux8/6/Dockerfile
@@ -350,6 +350,15 @@ RUN dnf -y install \
     && dnf clean all \
     && rm -rf /var/cache/dnf
 
+# python2.7 runtime dependencies
+RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output /tmp/get-pip.py \
+    && python2 /tmp/get-pip.py \
+    && pip2 install --no-cache-dir \
+        future==1.0.0 \
+    && rm -rf \ 
+      /tmp/get-pip.py \
+      /root/.cache/pip
+
 # Grab gosu for easy step-down from root
 # https://github.com/tianon/gosu/releases
 # https://github.com/tianon/gosu/blob/master/INSTALL.md

--- a/docker/greengage/oraclelinux8/6/Dockerfile
+++ b/docker/greengage/oraclelinux8/6/Dockerfile
@@ -9,8 +9,6 @@
 # PXF requires Java 17
 # See https://github.com/GreengageDB/pxf/commit/1a873abd57983bf658822cb9b02a11b011116812
 # ----
-# Wal-G currently disabled
-# ----
 # For compiling Greengage zstd static library (.a files) is needed.
 # See https://github.com/GreengageDB/greengage/commit/7185bf85ea8f4abdfdeb08d5a53180ea2f389728
 # On Ubuntu it's not needed as libzstd-dev contains .a files
@@ -19,7 +17,7 @@
 # ----
 ARG REPO_BUILD_TAG
 ARG OL_VERSION="8"
-ARG GOLANG_VERSION="1.24.11"
+ARG GOLANG_VERSION="1.25.11"
 ARG LIBSIGAR_DOWNLOAD_URL="https://github.com/boundary/sigar"
 ARG LIBSIGAR_COMMIT_HASH="e8961a6674cc4d292e61b353b5c36bfc345434cc"
 ARG GPDB_REPO_URL="https://github.com/GreengageDB/greengage.git"
@@ -33,13 +31,10 @@ ARG GPBACKUP_VERSION="1.31.1"
 ARG GPBACKUP_S3_PLUGIN_DOWNLOAD_URL="https://github.com/GreengageDB/gpbackup-s3-plugin/archive/refs/tags"
 ARG GPBACKUP_S3_PLUGIN_VERSION="1.11.0"
 ARG GPBACKMAN_DOWNLOAD_URL="https://github.com/woblerr/gpbackman/archive/refs/tags"
-ARG GPBACKMAN_VERSION="v0.8.1"
-# Greengage use pgBackRest fork for physical backups.
-# It is not clear whether wal-g will work correctly.
-# Will be error like: "unknown flavor: PostgreSQL 9.4.26 (Greengage Database 6.31.0 build dev)"
-#ARG WALG_DOWNLOAD_URL="https://github.com/wal-g/wal-g"
-## Wait new WAL-G release
-#ARG WALG_VERSION="4b33c88939ce0cc23acc5f89dcf5e427c50923d9"
+ARG GPBACKMAN_VERSION="v0.10.0"
+ARG WALG_DOWNLOAD_URL="https://github.com/wal-g/wal-g"
+# Wait new WAL-G release
+ARG WALG_VERSION="3c54030dda939d21a04adf9402adf9f45ce3d547"
 ARG GOSU_VERSION="1.19"
 ARG ZSTD_VERSION="1.5.7"
 ARG ZSTD_DOWNLOAD_URL="https://github.com/facebook/zstd/archive/refs/tags"
@@ -204,8 +199,8 @@ ARG GPBACKMAN_DOWNLOAD_URL
 ARG GPBACKMAN_VERSION
 ARG PXF_DOWNLOAD_URL
 ARG PXF_VERSION
-#ARG WALG_DOWNLOAD_URL
-#ARG WALG_VERSION
+ARG WALG_DOWNLOAD_URL
+ARG WALG_VERSION
 
 RUN mkdir -p /opt/go \
     && arch="$(uname -m)" \
@@ -245,15 +240,15 @@ RUN wget ${GPBACKMAN_DOWNLOAD_URL}/${GPBACKMAN_VERSION}.tar.gz -O /tmp/gpbackman
 ## wal-g
 ## Don't use USE_LZO=1, there is no need to build with WAL-E compatibility
 ## See https://github.com/wal-g/wal-g/issues/1412#issuecomment-1401890162
-#RUN git clone ${WALG_DOWNLOAD_URL} /tmp/wal-g \
-#    && cd /tmp/wal-g \
-#    && git checkout ${WALG_VERSION} \
-#    && USE_BROTLI=1 \
-#       USE_LIBSODIUM=1 \
-#       make deps \
-#    && USE_BROTLI=1 \
-#       USE_LIBSODIUM=1 \
-#       make gp_build
+RUN git clone ${WALG_DOWNLOAD_URL} /tmp/wal-g \
+    && cd /tmp/wal-g \
+    && git checkout ${WALG_VERSION} \
+    && USE_BROTLI=1 \
+       USE_LIBSODIUM=1 \
+       make deps \
+    && USE_BROTLI=1 \
+       USE_LIBSODIUM=1 \
+       make gp_build
 
 # pxf
 # Build pxf without tests
@@ -413,7 +408,7 @@ COPY --from=go_builder \
 COPY --from=go_builder /opt/go/bin/gpbackup_s3_plugin /usr/local/greenplum-db/bin/gpbackup_s3_plugin
 COPY --from=go_builder /usr/local/pxf /usr/local/pxf
 COPY --from=go_builder /tmp/gpbackman/gpbackman /usr/local/greenplum-db/bin/gpbackman
-#COPY --from=go_builder /tmp/wal-g/main/gp/wal-g /usr/local/greenplum-db/bin/wal-g
+COPY --from=go_builder /tmp/wal-g/main/gp/wal-g /usr/local/greenplum-db/bin/wal-g
 COPY --chmod=755 docker/files/entrypoint.sh /entrypoint.sh
 COPY --chmod=755 docker/files/start_gpdb.sh /start_gpdb.sh
 

--- a/docker/greengage/oraclelinux8/6/Dockerfile
+++ b/docker/greengage/oraclelinux8/6/Dockerfile
@@ -34,7 +34,7 @@ ARG GPBACKMAN_DOWNLOAD_URL="https://github.com/woblerr/gpbackman/archive/refs/ta
 ARG GPBACKMAN_VERSION="v0.10.0"
 ARG WALG_DOWNLOAD_URL="https://github.com/wal-g/wal-g"
 # Wait new WAL-G release
-ARG WALG_VERSION="3c54030dda939d21a04adf9402adf9f45ce3d547"
+ARG WALG_VERSION="e4843b849ca05a27655794888341de2662035853"
 ARG GOSU_VERSION="1.19"
 ARG ZSTD_VERSION="1.5.7"
 ARG ZSTD_DOWNLOAD_URL="https://github.com/facebook/zstd/archive/refs/tags"

--- a/docker/greengage/oraclelinux8/7/Dockerfile
+++ b/docker/greengage/oraclelinux8/7/Dockerfile
@@ -32,7 +32,7 @@ ARG GPBACKMAN_DOWNLOAD_URL="https://github.com/woblerr/gpbackman/archive/refs/ta
 ARG GPBACKMAN_VERSION="v0.10.0"
 ARG WALG_DOWNLOAD_URL="https://github.com/wal-g/wal-g"
 # Wait new WAL-G release
-ARG WALG_VERSION="3c54030dda939d21a04adf9402adf9f45ce3d547"
+ARG WALG_VERSION="e4843b849ca05a27655794888341de2662035853"
 ARG GOSU_VERSION="1.19"
 ARG ZSTD_VERSION="1.5.7"
 ARG ZSTD_DOWNLOAD_URL="https://github.com/facebook/zstd/archive/refs/tags"

--- a/docker/greengage/oraclelinux8/7/Dockerfile
+++ b/docker/greengage/oraclelinux8/7/Dockerfile
@@ -9,8 +9,6 @@
 # ----
 # Greengage 7 uses Python 3 (unlike Greengage 6 which used Python 2)
 # ----
-# Wal-G currently disabled
-# ----
 # For compiling Greengage zstd static library (.a files) is needed.
 # See https://github.com/GreengageDB/greengage/commit/7185bf85ea8f4abdfdeb08d5a53180ea2f389728
 # On Ubuntu it's not needed as libzstd-dev contains .a files
@@ -19,7 +17,7 @@
 # ----
 ARG REPO_BUILD_TAG
 ARG OL_VERSION="8"
-ARG GOLANG_VERSION="1.24.11"
+ARG GOLANG_VERSION="1.25.11"
 ARG GPDB_DOWNLOAD_URL="https://github.com/GreengageDB/greengage/archive/refs/tags"
 ARG GPDB_VERSION="7.4.1"
 ARG DISKQUOTA_DOWNLOAD_URL="https://github.com/GreengageDB/diskquota/archive/refs/tags"
@@ -31,13 +29,10 @@ ARG GPBACKUP_VERSION="1.31.1"
 ARG GPBACKUP_S3_PLUGIN_DOWNLOAD_URL="https://github.com/GreengageDB/gpbackup-s3-plugin/archive/refs/tags"
 ARG GPBACKUP_S3_PLUGIN_VERSION="1.11.0"
 ARG GPBACKMAN_DOWNLOAD_URL="https://github.com/woblerr/gpbackman/archive/refs/tags"
-ARG GPBACKMAN_VERSION="v0.8.1"
-# Greengage use pgBackRest fork for physical backups.
-# It is not clear whether wal-g will work correctly.
-# Will be error like: "unknown flavor: PostgreSQL ... (Greengage Database ... build dev)"
-#ARG WALG_DOWNLOAD_URL="https://github.com/wal-g/wal-g"
-## Wait new WAL-G release
-#ARG WALG_VERSION="4b33c88939ce0cc23acc5f89dcf5e427c50923d9"
+ARG GPBACKMAN_VERSION="v0.10.0"
+ARG WALG_DOWNLOAD_URL="https://github.com/wal-g/wal-g"
+# Wait new WAL-G release
+ARG WALG_VERSION="3c54030dda939d21a04adf9402adf9f45ce3d547"
 ARG GOSU_VERSION="1.19"
 ARG ZSTD_VERSION="1.5.7"
 ARG ZSTD_DOWNLOAD_URL="https://github.com/facebook/zstd/archive/refs/tags"
@@ -188,8 +183,8 @@ ARG GPBACKMAN_DOWNLOAD_URL
 ARG GPBACKMAN_VERSION
 ARG PXF_DOWNLOAD_URL
 ARG PXF_VERSION
-#ARG WALG_DOWNLOAD_URL
-#ARG WALG_VERSION
+ARG WALG_DOWNLOAD_URL
+ARG WALG_VERSION
 
 RUN mkdir -p /opt/go \
     && arch="$(uname -m)" \
@@ -229,15 +224,15 @@ RUN wget ${GPBACKMAN_DOWNLOAD_URL}/${GPBACKMAN_VERSION}.tar.gz -O /tmp/gpbackman
 ## wal-g
 ## Don't use USE_LZO=1, there is no need to build with WAL-E compatibility
 ## See https://github.com/wal-g/wal-g/issues/1412#issuecomment-1401890162
-#RUN git clone ${WALG_DOWNLOAD_URL} /tmp/wal-g \
-#    && cd /tmp/wal-g \
-#    && git checkout ${WALG_VERSION} \
-#    && USE_BROTLI=1 \
-#       USE_LIBSODIUM=1 \
-#       make deps \
-#    && USE_BROTLI=1 \
-#       USE_LIBSODIUM=1 \
-#       make gp_build
+RUN git clone ${WALG_DOWNLOAD_URL} /tmp/wal-g \
+    && cd /tmp/wal-g \
+    && git checkout ${WALG_VERSION} \
+    && USE_BROTLI=1 \
+       USE_LIBSODIUM=1 \
+       make deps \
+    && USE_BROTLI=1 \
+       USE_LIBSODIUM=1 \
+       make gp_build
 
 # pxf
 # Build pxf without tests
@@ -412,7 +407,7 @@ COPY --from=go_builder \
 COPY --from=go_builder /opt/go/bin/gpbackup_s3_plugin /usr/local/greenplum-db/bin/gpbackup_s3_plugin
 COPY --from=go_builder /usr/local/pxf /usr/local/pxf
 COPY --from=go_builder /tmp/gpbackman/gpbackman /usr/local/greenplum-db/bin/gpbackman
-#COPY --from=go_builder /tmp/wal-g/main/gp/wal-g /usr/local/greenplum-db/bin/wal-g
+COPY --from=go_builder /tmp/wal-g/main/gp/wal-g /usr/local/greenplum-db/bin/wal-g
 COPY --chmod=755 docker/files/entrypoint.sh /entrypoint.sh
 COPY --chmod=755 docker/files/start_gpdb.sh /start_gpdb.sh
 

--- a/docker/greengage/ubuntu22.04/6/Dockerfile
+++ b/docker/greengage/ubuntu22.04/6/Dockerfile
@@ -300,6 +300,13 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+# python2.7 runtime dependencies
+RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output /tmp/get-pip.py \
+    && python2.7 /tmp/get-pip.py \
+    && pip2.7 install --no-cache-dir \
+        future==1.0.0 \
+    && rm -rf /tmp/get-pip.py /root/.cache/pip
+
 RUN groupadd --gid ${GREENPLUM_GID} ${GREENPLUM_GROUP} \
     && useradd --shell /bin/bash --uid ${GREENPLUM_UID} --gid ${GREENPLUM_GID} -m ${GREENPLUM_USER} \
     && locale-gen en_US.UTF-8 \

--- a/docker/greengage/ubuntu22.04/6/Dockerfile
+++ b/docker/greengage/ubuntu22.04/6/Dockerfile
@@ -9,11 +9,9 @@
 # PXF requires Java 17
 # See https://github.com/GreengageDB/pxf/commit/1a873abd57983bf658822cb9b02a11b011116812
 # ----
-# Wal-G currently disabled
-# ----
 ARG REPO_BUILD_TAG
 ARG UBUNTU_VERSION="22.04"
-ARG GOLANG_VERSION="1.24.11"
+ARG GOLANG_VERSION="1.25.11"
 ARG LIBSIGAR_DOWNLOAD_URL="https://github.com/boundary/sigar"
 ARG LIBSIGAR_COMMIT_HASH="e8961a6674cc4d292e61b353b5c36bfc345434cc"
 ARG GPDB_REPO_URL="https://github.com/GreengageDB/greengage.git"
@@ -27,13 +25,10 @@ ARG GPBACKUP_VERSION="1.31.1"
 ARG GPBACKUP_S3_PLUGIN_DOWNLOAD_URL="https://github.com/GreengageDB/gpbackup-s3-plugin/archive/refs/tags"
 ARG GPBACKUP_S3_PLUGIN_VERSION="1.11.0"
 ARG GPBACKMAN_DOWNLOAD_URL="https://github.com/woblerr/gpbackman/archive/refs/tags"
-ARG GPBACKMAN_VERSION="v0.8.1"
-# Greengage use pgBackRest fork for physical backups.
-# It is not clear whether wal-g will work correctly.
-# Will be error like: "unknown flavor: PostgreSQL 9.4.26 (Greengage Database 6.31.0 build dev)"
-#ARG WALG_DOWNLOAD_URL="https://github.com/wal-g/wal-g"
-## Wait new WAL-G release
-#ARG WALG_VERSION="4b33c88939ce0cc23acc5f89dcf5e427c50923d9"
+ARG GPBACKMAN_VERSION="v0.10.0"
+ARG WALG_DOWNLOAD_URL="https://github.com/wal-g/wal-g"
+# Wait new WAL-G release
+ARG WALG_VERSION="3c54030dda939d21a04adf9402adf9f45ce3d547"
 
 FROM ubuntu:${UBUNTU_VERSION} AS builder
 
@@ -170,8 +165,8 @@ ARG GPBACKMAN_DOWNLOAD_URL
 ARG GPBACKMAN_VERSION
 ARG PXF_DOWNLOAD_URL
 ARG PXF_VERSION
-#ARG WALG_DOWNLOAD_URL
-#ARG WALG_VERSION
+ARG WALG_DOWNLOAD_URL
+ARG WALG_VERSION
 
 RUN mkdir -p /opt/go \
     && wget https://go.dev/dl/go${GOLANG_VERSION}.linux-$(dpkg --print-architecture).tar.gz \
@@ -205,15 +200,15 @@ RUN wget ${GPBACKMAN_DOWNLOAD_URL}/${GPBACKMAN_VERSION}.tar.gz -O /tmp/gpbackman
 ## wal-g
 ## Don't use USE_LZO=1, there is no need to build with WAL-E compatibility
 ## See https://github.com/wal-g/wal-g/issues/1412#issuecomment-1401890162
-#RUN git clone ${WALG_DOWNLOAD_URL} /tmp/wal-g \
-#    && cd /tmp/wal-g \
-#    && git checkout ${WALG_VERSION} \
-#    && USE_BROTLI=1 \
-#       USE_LIBSODIUM=1 \
-#       make deps \
-#    && USE_BROTLI=1 \
-#       USE_LIBSODIUM=1 \
-#       make gp_build
+RUN git clone ${WALG_DOWNLOAD_URL} /tmp/wal-g \
+    && cd /tmp/wal-g \
+    && git checkout ${WALG_VERSION} \
+    && USE_BROTLI=1 \
+       USE_LIBSODIUM=1 \
+       make deps \
+    && USE_BROTLI=1 \
+       USE_LIBSODIUM=1 \
+       make gp_build
 
 # pxf
 # Build pxf without tests
@@ -346,7 +341,7 @@ COPY --from=go_builder \
 COPY --from=go_builder /opt/go/bin/gpbackup_s3_plugin /usr/local/greenplum-db/bin/gpbackup_s3_plugin
 COPY --from=go_builder /usr/local/pxf /usr/local/pxf
 COPY --from=go_builder /tmp/gpbackman/gpbackman /usr/local/greenplum-db/bin/gpbackman
-#COPY --from=go_builder /tmp/wal-g/main/gp/wal-g /usr/local/greenplum-db/bin/wal-g
+COPY --from=go_builder /tmp/wal-g/main/gp/wal-g /usr/local/greenplum-db/bin/wal-g
 COPY --chmod=755 docker/files/entrypoint.sh /entrypoint.sh
 COPY --chmod=755 docker/files/start_gpdb.sh /start_gpdb.sh
 

--- a/docker/greengage/ubuntu22.04/6/Dockerfile
+++ b/docker/greengage/ubuntu22.04/6/Dockerfile
@@ -28,7 +28,7 @@ ARG GPBACKMAN_DOWNLOAD_URL="https://github.com/woblerr/gpbackman/archive/refs/ta
 ARG GPBACKMAN_VERSION="v0.10.0"
 ARG WALG_DOWNLOAD_URL="https://github.com/wal-g/wal-g"
 # Wait new WAL-G release
-ARG WALG_VERSION="3c54030dda939d21a04adf9402adf9f45ce3d547"
+ARG WALG_VERSION="e4843b849ca05a27655794888341de2662035853"
 
 FROM ubuntu:${UBUNTU_VERSION} AS builder
 

--- a/docker/greengage/ubuntu22.04/7/Dockerfile
+++ b/docker/greengage/ubuntu22.04/7/Dockerfile
@@ -24,7 +24,7 @@ ARG GPBACKMAN_DOWNLOAD_URL="https://github.com/woblerr/gpbackman/archive/refs/ta
 ARG GPBACKMAN_VERSION="v0.10.0"
 ARG WALG_DOWNLOAD_URL="https://github.com/wal-g/wal-g"
 # Wait new WAL-G release
-ARG WALG_VERSION="3c54030dda939d21a04adf9402adf9f45ce3d547"
+ARG WALG_VERSION="e4843b849ca05a27655794888341de2662035853"
 
 FROM ubuntu:${UBUNTU_VERSION} AS builder
 

--- a/docker/greengage/ubuntu22.04/7/Dockerfile
+++ b/docker/greengage/ubuntu22.04/7/Dockerfile
@@ -7,11 +7,9 @@
 # PXF requires Java 17
 # See https://github.com/GreengageDB/pxf/commit/1a873abd57983bf658822cb9b02a11b011116812
 # ----
-# Wal-G currently disabled
-# ----
 ARG REPO_BUILD_TAG
 ARG UBUNTU_VERSION="22.04"
-ARG GOLANG_VERSION="1.24.11"
+ARG GOLANG_VERSION="1.25.11"
 ARG GPDB_DOWNLOAD_URL="https://github.com/GreengageDB/greengage/archive/refs/tags"
 ARG GPDB_VERSION="7.4.1"
 ARG DISKQUOTA_DOWNLOAD_URL="https://github.com/GreengageDB/diskquota/archive/refs/tags"
@@ -23,13 +21,10 @@ ARG GPBACKUP_VERSION="1.31.1"
 ARG GPBACKUP_S3_PLUGIN_DOWNLOAD_URL="https://github.com/GreengageDB/gpbackup-s3-plugin/archive/refs/tags"
 ARG GPBACKUP_S3_PLUGIN_VERSION="1.11.0"
 ARG GPBACKMAN_DOWNLOAD_URL="https://github.com/woblerr/gpbackman/archive/refs/tags"
-ARG GPBACKMAN_VERSION="v0.8.1"
-# Greengage use pgBackRest fork for physical backups.
-# It is not clear whether wal-g will work correctly.
-# Will be error like: "unknown flavor: PostgreSQL ... (Greengage Database ... build dev)"
-#ARG WALG_DOWNLOAD_URL="https://github.com/wal-g/wal-g"
-## Wait new WAL-G release
-#ARG WALG_VERSION="4b33c88939ce0cc23acc5f89dcf5e427c50923d9"
+ARG GPBACKMAN_VERSION="v0.10.0"
+ARG WALG_DOWNLOAD_URL="https://github.com/wal-g/wal-g"
+# Wait new WAL-G release
+ARG WALG_VERSION="3c54030dda939d21a04adf9402adf9f45ce3d547"
 
 FROM ubuntu:${UBUNTU_VERSION} AS builder
 
@@ -153,8 +148,8 @@ ARG GPBACKMAN_DOWNLOAD_URL
 ARG GPBACKMAN_VERSION
 ARG PXF_DOWNLOAD_URL
 ARG PXF_VERSION
-#ARG WALG_DOWNLOAD_URL
-#ARG WALG_VERSION
+ARG WALG_DOWNLOAD_URL
+ARG WALG_VERSION
 
 RUN mkdir -p /opt/go \
     && wget https://go.dev/dl/go${GOLANG_VERSION}.linux-$(dpkg --print-architecture).tar.gz \
@@ -188,15 +183,15 @@ RUN wget ${GPBACKMAN_DOWNLOAD_URL}/${GPBACKMAN_VERSION}.tar.gz -O /tmp/gpbackman
 ## wal-g
 ## Don't use USE_LZO=1, there is no need to build with WAL-E compatibility
 ## See https://github.com/wal-g/wal-g/issues/1412#issuecomment-1401890162
-#RUN git clone ${WALG_DOWNLOAD_URL} /tmp/wal-g \
-#    && cd /tmp/wal-g \
-#    && git checkout ${WALG_VERSION} \
-#    && USE_BROTLI=1 \
-#       USE_LIBSODIUM=1 \
-#       make deps \
-#    && USE_BROTLI=1 \
-#       USE_LIBSODIUM=1 \
-#       make gp_build
+RUN git clone ${WALG_DOWNLOAD_URL} /tmp/wal-g \
+    && cd /tmp/wal-g \
+    && git checkout ${WALG_VERSION} \
+    && USE_BROTLI=1 \
+       USE_LIBSODIUM=1 \
+       make deps \
+    && USE_BROTLI=1 \
+       USE_LIBSODIUM=1 \
+       make gp_build
 
 # pxf
 # Build pxf without tests
@@ -334,7 +329,7 @@ COPY --from=go_builder \
 COPY --from=go_builder /opt/go/bin/gpbackup_s3_plugin /usr/local/greenplum-db/bin/gpbackup_s3_plugin
 COPY --from=go_builder /usr/local/pxf /usr/local/pxf
 COPY --from=go_builder /tmp/gpbackman/gpbackman /usr/local/greenplum-db/bin/gpbackman
-#COPY --from=go_builder /tmp/wal-g/main/gp/wal-g /usr/local/greenplum-db/bin/wal-g
+COPY --from=go_builder /tmp/wal-g/main/gp/wal-g /usr/local/greenplum-db/bin/wal-g
 COPY --chmod=755 docker/files/entrypoint.sh /entrypoint.sh
 COPY --chmod=755 docker/files/start_gpdb.sh /start_gpdb.sh
 

--- a/docker/greenplum/oraclelinux8/6/Dockerfile
+++ b/docker/greenplum/oraclelinux8/6/Dockerfile
@@ -1,6 +1,6 @@
 ARG REPO_BUILD_TAG
 ARG OL_VERSION="8"
-ARG GOLANG_VERSION="1.24.11"
+ARG GOLANG_VERSION="1.25.11"
 ARG GPXERCES_DOWNLOAD_URL="https://github.com/woblerr/gp-xerces/archive/refs/tags"
 ARG GPXERCES_VERSION="v3.1.2-p1"
 ARG LIBSIGAR_DOWNLOAD_URL="https://github.com/boundary/sigar"
@@ -16,10 +16,10 @@ ARG GPBACKUP_VERSION="1.30.5"
 ARG GPBACKUP_S3_PLUGIN_DOWNLOAD_URL="https://github.com/woblerr/gpbackup-s3-plugin/archive/refs/tags"
 ARG GPBACKUP_S3_PLUGIN_VERSION="1.10.2"
 ARG GPBACKMAN_DOWNLOAD_URL="https://github.com/woblerr/gpbackman/archive/refs/tags"
-ARG GPBACKMAN_VERSION="v0.8.1"
+ARG GPBACKMAN_VERSION="v0.10.0"
 ARG WALG_DOWNLOAD_URL="https://github.com/wal-g/wal-g"
 # Wait new WAL-G release
-ARG WALG_VERSION="4b33c88939ce0cc23acc5f89dcf5e427c50923d9"
+ARG WALG_VERSION="3c54030dda939d21a04adf9402adf9f45ce3d547"
 ARG GOSU_VERSION="1.19"
 
 FROM oraclelinux:${OL_VERSION} AS builder

--- a/docker/greenplum/oraclelinux8/6/Dockerfile
+++ b/docker/greenplum/oraclelinux8/6/Dockerfile
@@ -19,7 +19,7 @@ ARG GPBACKMAN_DOWNLOAD_URL="https://github.com/woblerr/gpbackman/archive/refs/ta
 ARG GPBACKMAN_VERSION="v0.10.0"
 ARG WALG_DOWNLOAD_URL="https://github.com/wal-g/wal-g"
 # Wait new WAL-G release
-ARG WALG_VERSION="3c54030dda939d21a04adf9402adf9f45ce3d547"
+ARG WALG_VERSION="e4843b849ca05a27655794888341de2662035853"
 ARG GOSU_VERSION="1.19"
 
 FROM oraclelinux:${OL_VERSION} AS builder

--- a/docker/greenplum/oraclelinux8/7/Dockerfile
+++ b/docker/greenplum/oraclelinux8/7/Dockerfile
@@ -1,6 +1,6 @@
 ARG REPO_BUILD_TAG
 ARG OL_VERSION="8"
-ARG GOLANG_VERSION="1.24.11"
+ARG GOLANG_VERSION="1.25.11"
 ARG GPXERCES_DOWNLOAD_URL="https://github.com/woblerr/gp-xerces/archive/refs/tags"
 ARG GPXERCES_VERSION="v3.1.2-p1"
 ARG GPDB_DOWNLOAD_URL="https://github.com/woblerr/gpdb/archive/refs/tags"
@@ -14,10 +14,10 @@ ARG GPBACKUP_VERSION="1.30.5"
 ARG GPBACKUP_S3_PLUGIN_DOWNLOAD_URL="https://github.com/woblerr/gpbackup-s3-plugin/archive/refs/tags"
 ARG GPBACKUP_S3_PLUGIN_VERSION="1.10.2"
 ARG GPBACKMAN_DOWNLOAD_URL="https://github.com/woblerr/gpbackman/archive/refs/tags"
-ARG GPBACKMAN_VERSION="v0.8.1"
+ARG GPBACKMAN_VERSION="v0.10.0"
 ARG WALG_DOWNLOAD_URL="https://github.com/wal-g/wal-g"
 # Wait new WAL-G release
-ARG WALG_VERSION="4b33c88939ce0cc23acc5f89dcf5e427c50923d9"
+ARG WALG_VERSION="3c54030dda939d21a04adf9402adf9f45ce3d547"
 ARG GOSU_VERSION="1.19"
 
 FROM oraclelinux:${OL_VERSION} AS builder

--- a/docker/greenplum/oraclelinux8/7/Dockerfile
+++ b/docker/greenplum/oraclelinux8/7/Dockerfile
@@ -17,7 +17,7 @@ ARG GPBACKMAN_DOWNLOAD_URL="https://github.com/woblerr/gpbackman/archive/refs/ta
 ARG GPBACKMAN_VERSION="v0.10.0"
 ARG WALG_DOWNLOAD_URL="https://github.com/wal-g/wal-g"
 # Wait new WAL-G release
-ARG WALG_VERSION="3c54030dda939d21a04adf9402adf9f45ce3d547"
+ARG WALG_VERSION="e4843b849ca05a27655794888341de2662035853"
 ARG GOSU_VERSION="1.19"
 
 FROM oraclelinux:${OL_VERSION} AS builder

--- a/docker/greenplum/ubuntu22.04/6/Dockerfile
+++ b/docker/greenplum/ubuntu22.04/6/Dockerfile
@@ -19,7 +19,7 @@ ARG GPBACKMAN_DOWNLOAD_URL="https://github.com/woblerr/gpbackman/archive/refs/ta
 ARG GPBACKMAN_VERSION="v0.10.0"
 ARG WALG_DOWNLOAD_URL="https://github.com/wal-g/wal-g"
 # Wait new WAL-G release
-ARG WALG_VERSION="3c54030dda939d21a04adf9402adf9f45ce3d547"
+ARG WALG_VERSION="e4843b849ca05a27655794888341de2662035853"
 
 FROM ubuntu:${UBUNTU_VERSION} AS builder
 

--- a/docker/greenplum/ubuntu22.04/6/Dockerfile
+++ b/docker/greenplum/ubuntu22.04/6/Dockerfile
@@ -1,6 +1,6 @@
 ARG REPO_BUILD_TAG
 ARG UBUNTU_VERSION="22.04"
-ARG GOLANG_VERSION="1.24.11"
+ARG GOLANG_VERSION="1.25.11"
 ARG GPXERCES_DOWNLOAD_URL="https://github.com/woblerr/gp-xerces/archive/refs/tags"
 ARG GPXERCES_VERSION="v3.1.2-p1"
 ARG LIBSIGAR_DOWNLOAD_URL="https://github.com/boundary/sigar"
@@ -16,10 +16,10 @@ ARG GPBACKUP_VERSION="1.30.5"
 ARG GPBACKUP_S3_PLUGIN_DOWNLOAD_URL="https://github.com/woblerr/gpbackup-s3-plugin/archive/refs/tags"
 ARG GPBACKUP_S3_PLUGIN_VERSION="1.10.2"
 ARG GPBACKMAN_DOWNLOAD_URL="https://github.com/woblerr/gpbackman/archive/refs/tags"
-ARG GPBACKMAN_VERSION="v0.8.1"
+ARG GPBACKMAN_VERSION="v0.10.0"
 ARG WALG_DOWNLOAD_URL="https://github.com/wal-g/wal-g"
 # Wait new WAL-G release
-ARG WALG_VERSION="4b33c88939ce0cc23acc5f89dcf5e427c50923d9"
+ARG WALG_VERSION="3c54030dda939d21a04adf9402adf9f45ce3d547"
 
 FROM ubuntu:${UBUNTU_VERSION} AS builder
 

--- a/docker/greenplum/ubuntu22.04/7/Dockerfile
+++ b/docker/greenplum/ubuntu22.04/7/Dockerfile
@@ -17,7 +17,7 @@ ARG GPBACKMAN_DOWNLOAD_URL="https://github.com/woblerr/gpbackman/archive/refs/ta
 ARG GPBACKMAN_VERSION="v0.10.0"
 ARG WALG_DOWNLOAD_URL="https://github.com/wal-g/wal-g"
 # Wait new WAL-G release
-ARG WALG_VERSION="3c54030dda939d21a04adf9402adf9f45ce3d547"
+ARG WALG_VERSION="e4843b849ca05a27655794888341de2662035853"
 
 FROM ubuntu:${UBUNTU_VERSION} AS builder
 

--- a/docker/greenplum/ubuntu22.04/7/Dockerfile
+++ b/docker/greenplum/ubuntu22.04/7/Dockerfile
@@ -1,6 +1,6 @@
 ARG REPO_BUILD_TAG
 ARG UBUNTU_VERSION="22.04"
-ARG GOLANG_VERSION="1.24.11"
+ARG GOLANG_VERSION="1.25.11"
 ARG GPXERCES_DOWNLOAD_URL="https://github.com/woblerr/gp-xerces/archive/refs/tags"
 ARG GPXERCES_VERSION="v3.1.2-p1"
 ARG GPDB_DOWNLOAD_URL="https://github.com/woblerr/gpdb/archive/refs/tags"
@@ -14,10 +14,10 @@ ARG GPBACKUP_VERSION="1.30.5"
 ARG GPBACKUP_S3_PLUGIN_DOWNLOAD_URL="https://github.com/woblerr/gpbackup-s3-plugin/archive/refs/tags"
 ARG GPBACKUP_S3_PLUGIN_VERSION="1.10.2"
 ARG GPBACKMAN_DOWNLOAD_URL="https://github.com/woblerr/gpbackman/archive/refs/tags"
-ARG GPBACKMAN_VERSION="v0.8.1"
+ARG GPBACKMAN_VERSION="v0.10.0"
 ARG WALG_DOWNLOAD_URL="https://github.com/wal-g/wal-g"
 # Wait new WAL-G release
-ARG WALG_VERSION="4b33c88939ce0cc23acc5f89dcf5e427c50923d9"
+ARG WALG_VERSION="3c54030dda939d21a04adf9402adf9f45ce3d547"
 
 FROM ubuntu:${UBUNTU_VERSION} AS builder
 

--- a/docker/opengpdb/ubuntu22.04/6/Dockerfile
+++ b/docker/opengpdb/ubuntu22.04/6/Dockerfile
@@ -19,7 +19,7 @@ ARG GPBACKMAN_DOWNLOAD_URL="https://github.com/woblerr/gpbackman/archive/refs/ta
 ARG GPBACKMAN_VERSION="v0.10.0"
 ARG WALG_DOWNLOAD_URL="https://github.com/wal-g/wal-g"
 # Wait new WAL-G release
-ARG WALG_VERSION="3c54030dda939d21a04adf9402adf9f45ce3d547"
+ARG WALG_VERSION="e4843b849ca05a27655794888341de2662035853"
 ARG YPROXY_DOWNLOAD_URL="https://github.com/open-gpdb/yproxy/archive/refs/tags"
 ARG YPROXY_VERSION="1.7.5"
 ARG YEZZEY_DOWNLOAD_URL="https://github.com/open-gpdb/yezzey"

--- a/docker/warehousepg/oraclelinux8/6/Dockerfile
+++ b/docker/warehousepg/oraclelinux8/6/Dockerfile
@@ -5,7 +5,7 @@
 # ----
 ARG REPO_BUILD_TAG
 ARG OL_VERSION="8"
-ARG GOLANG_VERSION="1.24.11"
+ARG GOLANG_VERSION="1.25.11"
 ARG GPXERCES_DOWNLOAD_URL="https://github.com/woblerr/gp-xerces/archive/refs/tags"
 ARG GPXERCES_VERSION="v3.1.2-p1"
 ARG LIBSIGAR_DOWNLOAD_URL="https://github.com/boundary/sigar"
@@ -21,10 +21,10 @@ ARG GPBACKUP_VERSION="1.30.5"
 ARG GPBACKUP_S3_PLUGIN_DOWNLOAD_URL="https://github.com/woblerr/gpbackup-s3-plugin/archive/refs/tags"
 ARG GPBACKUP_S3_PLUGIN_VERSION="1.10.2"
 ARG GPBACKMAN_DOWNLOAD_URL="https://github.com/woblerr/gpbackman/archive/refs/tags"
-ARG GPBACKMAN_VERSION="v0.8.1"
+ARG GPBACKMAN_VERSION="v0.10.0"
 ARG WALG_DOWNLOAD_URL="https://github.com/wal-g/wal-g"
 # Wait new WAL-G release
-ARG WALG_VERSION="4b33c88939ce0cc23acc5f89dcf5e427c50923d9"
+ARG WALG_VERSION="3c54030dda939d21a04adf9402adf9f45ce3d547"
 ARG GOSU_VERSION="1.19"
 
 FROM oraclelinux:${OL_VERSION} AS builder

--- a/docker/warehousepg/oraclelinux8/6/Dockerfile
+++ b/docker/warehousepg/oraclelinux8/6/Dockerfile
@@ -24,7 +24,7 @@ ARG GPBACKMAN_DOWNLOAD_URL="https://github.com/woblerr/gpbackman/archive/refs/ta
 ARG GPBACKMAN_VERSION="v0.10.0"
 ARG WALG_DOWNLOAD_URL="https://github.com/wal-g/wal-g"
 # Wait new WAL-G release
-ARG WALG_VERSION="3c54030dda939d21a04adf9402adf9f45ce3d547"
+ARG WALG_VERSION="e4843b849ca05a27655794888341de2662035853"
 ARG GOSU_VERSION="1.19"
 
 FROM oraclelinux:${OL_VERSION} AS builder

--- a/docker/warehousepg/oraclelinux8/7/Dockerfile
+++ b/docker/warehousepg/oraclelinux8/7/Dockerfile
@@ -5,7 +5,7 @@
 # ----
 ARG REPO_BUILD_TAG
 ARG OL_VERSION="8"
-ARG GOLANG_VERSION="1.24.11"
+ARG GOLANG_VERSION="1.25.11"
 ARG GPXERCES_DOWNLOAD_URL="https://github.com/woblerr/gp-xerces/archive/refs/tags"
 ARG GPXERCES_VERSION="v3.1.2-p1"
 ARG GPDB_DOWNLOAD_URL="https://github.com/warehouse-pg/warehouse-pg/archive/refs/tags"
@@ -19,10 +19,10 @@ ARG GPBACKUP_VERSION="1.30.5"
 ARG GPBACKUP_S3_PLUGIN_DOWNLOAD_URL="https://github.com/woblerr/gpbackup-s3-plugin/archive/refs/tags"
 ARG GPBACKUP_S3_PLUGIN_VERSION="1.10.2"
 ARG GPBACKMAN_DOWNLOAD_URL="https://github.com/woblerr/gpbackman/archive/refs/tags"
-ARG GPBACKMAN_VERSION="v0.8.1"
+ARG GPBACKMAN_VERSION="v0.10.0"
 ARG WALG_DOWNLOAD_URL="https://github.com/wal-g/wal-g"
 # Wait new WAL-G release
-ARG WALG_VERSION="4b33c88939ce0cc23acc5f89dcf5e427c50923d9"
+ARG WALG_VERSION="3c54030dda939d21a04adf9402adf9f45ce3d547"
 ARG GOSU_VERSION="1.19"
 
 FROM oraclelinux:${OL_VERSION} AS builder

--- a/docker/warehousepg/oraclelinux8/7/Dockerfile
+++ b/docker/warehousepg/oraclelinux8/7/Dockerfile
@@ -22,7 +22,7 @@ ARG GPBACKMAN_DOWNLOAD_URL="https://github.com/woblerr/gpbackman/archive/refs/ta
 ARG GPBACKMAN_VERSION="v0.10.0"
 ARG WALG_DOWNLOAD_URL="https://github.com/wal-g/wal-g"
 # Wait new WAL-G release
-ARG WALG_VERSION="3c54030dda939d21a04adf9402adf9f45ce3d547"
+ARG WALG_VERSION="e4843b849ca05a27655794888341de2662035853"
 ARG GOSU_VERSION="1.19"
 
 FROM oraclelinux:${OL_VERSION} AS builder

--- a/docker/warehousepg/ubuntu22.04/6/Dockerfile
+++ b/docker/warehousepg/ubuntu22.04/6/Dockerfile
@@ -24,7 +24,7 @@ ARG GPBACKMAN_DOWNLOAD_URL="https://github.com/woblerr/gpbackman/archive/refs/ta
 ARG GPBACKMAN_VERSION="v0.10.0"
 ARG WALG_DOWNLOAD_URL="https://github.com/wal-g/wal-g"
 # Wait new WAL-G release
-ARG WALG_VERSION="3c54030dda939d21a04adf9402adf9f45ce3d547"
+ARG WALG_VERSION="e4843b849ca05a27655794888341de2662035853"
 
 FROM ubuntu:${UBUNTU_VERSION} AS builder
 

--- a/docker/warehousepg/ubuntu22.04/6/Dockerfile
+++ b/docker/warehousepg/ubuntu22.04/6/Dockerfile
@@ -5,7 +5,7 @@
 # ----
 ARG REPO_BUILD_TAG
 ARG UBUNTU_VERSION="22.04"
-ARG GOLANG_VERSION="1.24.11"
+ARG GOLANG_VERSION="1.25.11"
 ARG GPXERCES_DOWNLOAD_URL="https://github.com/woblerr/gp-xerces/archive/refs/tags"
 ARG GPXERCES_VERSION="v3.1.2-p1"
 ARG LIBSIGAR_DOWNLOAD_URL="https://github.com/boundary/sigar"
@@ -21,10 +21,10 @@ ARG GPBACKUP_VERSION="1.30.5"
 ARG GPBACKUP_S3_PLUGIN_DOWNLOAD_URL="https://github.com/woblerr/gpbackup-s3-plugin/archive/refs/tags"
 ARG GPBACKUP_S3_PLUGIN_VERSION="1.10.2"
 ARG GPBACKMAN_DOWNLOAD_URL="https://github.com/woblerr/gpbackman/archive/refs/tags"
-ARG GPBACKMAN_VERSION="v0.8.1"
+ARG GPBACKMAN_VERSION="v0.10.0"
 ARG WALG_DOWNLOAD_URL="https://github.com/wal-g/wal-g"
 # Wait new WAL-G release
-ARG WALG_VERSION="4b33c88939ce0cc23acc5f89dcf5e427c50923d9"
+ARG WALG_VERSION="3c54030dda939d21a04adf9402adf9f45ce3d547"
 
 FROM ubuntu:${UBUNTU_VERSION} AS builder
 

--- a/docker/warehousepg/ubuntu22.04/7/Dockerfile
+++ b/docker/warehousepg/ubuntu22.04/7/Dockerfile
@@ -5,7 +5,7 @@
 # ----
 ARG REPO_BUILD_TAG
 ARG UBUNTU_VERSION="22.04"
-ARG GOLANG_VERSION="1.24.11"
+ARG GOLANG_VERSION="1.25.11"
 ARG GPXERCES_DOWNLOAD_URL="https://github.com/woblerr/gp-xerces/archive/refs/tags"
 ARG GPXERCES_VERSION="v3.1.2-p1"
 ARG GPDB_DOWNLOAD_URL="https://github.com/warehouse-pg/warehouse-pg/archive/refs/tags"
@@ -19,10 +19,10 @@ ARG GPBACKUP_VERSION="1.30.5"
 ARG GPBACKUP_S3_PLUGIN_DOWNLOAD_URL="https://github.com/woblerr/gpbackup-s3-plugin/archive/refs/tags"
 ARG GPBACKUP_S3_PLUGIN_VERSION="1.10.2"
 ARG GPBACKMAN_DOWNLOAD_URL="https://github.com/woblerr/gpbackman/archive/refs/tags"
-ARG GPBACKMAN_VERSION="v0.8.1"
+ARG GPBACKMAN_VERSION="v0.10.0"
 ARG WALG_DOWNLOAD_URL="https://github.com/wal-g/wal-g"
 # Wait new WAL-G release
-ARG WALG_VERSION="4b33c88939ce0cc23acc5f89dcf5e427c50923d9"
+ARG WALG_VERSION="3c54030dda939d21a04adf9402adf9f45ce3d547"
 
 FROM ubuntu:${UBUNTU_VERSION} AS builder
 

--- a/docker/warehousepg/ubuntu22.04/7/Dockerfile
+++ b/docker/warehousepg/ubuntu22.04/7/Dockerfile
@@ -22,7 +22,7 @@ ARG GPBACKMAN_DOWNLOAD_URL="https://github.com/woblerr/gpbackman/archive/refs/ta
 ARG GPBACKMAN_VERSION="v0.10.0"
 ARG WALG_DOWNLOAD_URL="https://github.com/wal-g/wal-g"
 # Wait new WAL-G release
-ARG WALG_VERSION="3c54030dda939d21a04adf9402adf9f45ce3d547"
+ARG WALG_VERSION="e4843b849ca05a27655794888341de2662035853"
 
 FROM ubuntu:${UBUNTU_VERSION} AS builder
 

--- a/e2e-tests/.env
+++ b/e2e-tests/.env
@@ -29,6 +29,37 @@ RESTORE_CONFIG_FOLDER="6"
 #RESTORE_TAG=7.1.0-oraclelinux8
 #RESTORE_CONFIG_FOLDER="7"
 
+# Greengage
+# -------------------------------------
+#IMAGE_NAME="greengage"
+# For Greengage 6 on Ubuntu 22.04
+#TAG=6.31.0-ubuntu22.04
+#CONFIG_FOLDER="6"
+# For Greengage 6 on Oracle Linux 8
+#TAG=6.31.0-oraclelinux8
+#CONFIG_FOLDER="6"
+# For Greengage 7 on Ubuntu 22.04
+#TAG=7.4.1-ubuntu22.04
+#CONFIG_FOLDER="7"
+# For Greengage 7 on Oracle Linux 8
+#TAG=7.4.1-oraclelinux8
+#CONFIG_FOLDER="7"
+
+# Greengage RESTORE
+# -------------------------------------
+# For Greengage 6 on Ubuntu 22.04
+#RESTORE_TAG=6.31.0-ubuntu22.04
+#RESTORE_CONFIG_FOLDER="6"
+# For Greengage 6 on Oracle Linux 8
+#RESTORE_TAG=6.31.0-oraclelinux8
+#RESTORE_CONFIG_FOLDER="6"
+# For Greengage 7 on Ubuntu 22.04
+#RESTORE_TAG=7.4.1-ubuntu22.04
+#RESTORE_CONFIG_FOLDER="7"
+# For Greengage 7 on Oracle Linux 8
+#RESTORE_TAG=7.4.1-oraclelinux8
+#RESTORE_CONFIG_FOLDER="7"
+
 # WarehousePG
 # -------------------------------------
 #IMAGE_NAME="warehousepg"

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -26,7 +26,7 @@ make test-e2e
 
 Primary cluster is described in `e2e-tests/docker-compose.gpdb.yml`, standby cluster is described in `e2e-tests/docker-compose.gpdb-restore.yml`, and S3 compatible storage is described in `e2e-tests/docker-compose.s3.yml`.
 
-The test validates WAL-G backup and restore functionality for Greenplum (works with GPDB and WarehousePG; **not supported for Greengage** due to changed database flavor):
+The test validates WAL-G backup and restore functionality for Greenplum-compatible images with WAL-G support:
 
 1. **Full backup test**:
    - Creates full backup on primary cluster
@@ -59,7 +59,7 @@ or manually:
 ```bash
 cd [docker-greenplum-root]/e2e-tests
 docker compose -f docker-compose.s3.yml -f docker-compose.gpdb.yml -f docker-compose.gpdb-restore.yml up -d
-GREENPLUM_PASSWORD=$(cat ../docker-compose/secrets/gpdb_password) ./scripts/e2e-test.sh
+GREENPLUM_PASSWORD=$(cat ../docker-compose/secrets/gpdb_password) GP_VERSION=$(grep '^CONFIG_FOLDER=' .env | head -1 | cut -d'=' -f2 | tr -d '"') ./scripts/e2e-test.sh
 docker compose -f docker-compose.s3.yml -f docker-compose.gpdb.yml -f docker-compose.gpdb-restore.yml down
 ```
 


### PR DESCRIPTION
* Bump go to `1.25.11` for gpdb, whpg, ggdb images.
* Bump gpbackman to `v0.10.0` for gpdb, whpg, ggdb images.
* Bump, wal-g to `e4843b8` for all images.
* Add wal-g for ggdb. Add e2e tests wit wal-g for ggdb.